### PR TITLE
Disallow extra else in regular expressions

### DIFF
--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -37,6 +37,7 @@ export type DiagnosticCategory =
   | 'lint/noDuplicateKeys'
   | 'lint/noEmptyCharacterClass'
   | 'lint/noExtraBooleanCast'
+  | 'lint/noExtraElseInRegEx'
   | 'lint/noFunctionAssign'
   | 'lint/noImportAssign'
   | 'lint/noLabelVar'

--- a/packages/@romejs/js-compiler/transforms/lint/index.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/index.ts
@@ -21,6 +21,7 @@ import noDuplicateCase from './noDuplicateCase';
 import noDuplicateKeys from './noDuplicateKeys';
 import noEmptyCharacterClass from './noEmptyCharacterClass';
 import noExtraBooleanCast from './noExtraBooleanCast';
+import noExtraElseInRegEx from './noExtraElseInRegEx';
 import noFunctionAssign from './noFunctionAssign';
 import noImportAssign from './noImportAssign';
 import noLabelVar from './noLabelVar';
@@ -51,6 +52,7 @@ export const lintTransforms = [
   noDuplicateKeys,
   noEmptyCharacterClass,
   noExtraBooleanCast,
+  noExtraElseInRegEx,
   noFunctionAssign,
   noImportAssign,
   noLabelVar,

--- a/packages/@romejs/js-compiler/transforms/lint/noExtraElseInRegEx.test.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noExtraElseInRegEx.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import test from '@romejs/test';
+import {testLint} from '../../api/lint.test';
+
+test('disallow unnecessary boolean casts', async t => {
+  const regexExtraElseTest = await testLint(
+    `
+    let reg = /|Hello|World|/;
+    reg.test('Hello');
+    `,
+  );
+
+  t.truthy(
+    regexExtraElseTest.diagnostics.find(
+      d => d.message === `Extra else in regular expressions is not allowed.`,
+    ),
+  );
+});

--- a/packages/@romejs/js-compiler/transforms/lint/noExtraElseInRegEx.ts
+++ b/packages/@romejs/js-compiler/transforms/lint/noExtraElseInRegEx.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Path} from '@romejs/js-compiler';
+import {AnyNode} from '@romejs/js-ast';
+
+export default {
+  name: 'noExtraElseInRegEx',
+  enter(path: Path): AnyNode {
+    const {node, context} = path;
+
+    if (node.type === 'RegExpSubExpression') {
+      if (node.body.length === 0) {
+        context.addNodeDiagnostic(node, {
+          category: 'lint/noExtraElseInRegEx',
+          message: `Extra else in regular expressions is not allowed.`,
+        });
+      }
+    }
+
+    return node;
+  },
+};


### PR DESCRIPTION
I'm not really sure if I'm doing the right thing here so please point me in the right direction if I'm lost. Part of issue #159. I'm testing regexs where there is no condition to check after an alternation `|` eg

```
let reg = /|Hello|World|/;
```

The result looks like this

<img width="494" alt="Screenshot 2020-03-12 at 13 21 08" src="https://user-images.githubusercontent.com/806774/76516615-63143f80-6464-11ea-8023-c6a45dcaffbe.png">
