### PR TITLE
Add autofix for preferTemplate rule

### DIFF
--- a/packages/@romejs/cli-diagnostics/buildMessageCodeFrame.ts
+++ b/packages/@romejs/cli-diagnostics/buildMessageCodeFrame.ts
@@ -198,9 +198,7 @@ export default function buildMessageCodeFrame(
   const markerLine: string = `${markerGutterIndent}<emphasis>${GUTTER}</emphasis>${pointerIndent}${pointer} ${markerMessage}`;
 
   // Build up the line we display when source lines are omitted
-  const omittedLine =
-    `<pad count="${String(maxGutterLength)}"><emphasis>...</emphasis></pad>` +
-    GUTTER;
+  const omittedLine = `<pad count="${String(maxGutterLength)}"><emphasis>...</emphasis></pad>${GUTTER}`;
 
   // Build the frame
   const result = [];
@@ -216,8 +214,7 @@ export default function buildMessageCodeFrame(
       result.push(line);
     } else {
       result.push(
-        `<emphasis><pad count="${String(maxGutterLength)}">${gutter}</pad></emphasis>` +
-        line,
+        `<emphasis><pad count="${String(maxGutterLength)}">${gutter}</pad></emphasis>${line}`,
       );
     }
     if (lineIndex === endLineIndex && !noMarkerLine) {

--- a/packages/@romejs/codec-json/parser-test262.test.ts
+++ b/packages/@romejs/codec-json/parser-test262.test.ts
@@ -123,8 +123,7 @@ test(
   'Whitespace characters can appear before/after any JSONtoken',
   () => {
     parse(
-      `\t\r \n{\t\r \n"property"\t\r \n:\t\r \n{\t\r \n}\t\r \n,\t\r \n"prop2"\t\r \n:\t\r \n` +
-      `[\t\r \ntrue\t\r \n,\t\r \nnull\t\r \n,123.456\t\r \n]\t\r \n}\t\r \n`,
+      `\t\r \n{\t\r \n"property"\t\r \n:\t\r \n{\t\r \n}\t\r \n,\t\r \n"prop2"\t\r \n:\t\r \n[\t\r \ntrue\t\r \n,\t\r \nnull\t\r \n,123.456\t\r \n]\t\r \n}\t\r \n`,
     ); // should JOSN parse without error
   },
 );

--- a/packages/@romejs/core/master/testing/TestRunner.ts
+++ b/packages/@romejs/core/master/testing/TestRunner.ts
@@ -762,7 +762,7 @@ export default class TestRunner {
       const folderPercent = percentInsideCoverageFolder(folder);
 
       rows.push([
-        ' '.repeat(depth) + `<emphasis>${name}</emphasis>`,
+        `${' '.repeat(depth)}<emphasis>${name}</emphasis>`,
         formatPercent(folderPercent.functions),
         formatPercent(folderPercent.branches),
         formatPercent(folderPercent.lines),

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.md
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.md
@@ -8,17 +8,17 @@
 
 ```
 
- unknown:1:31 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:12 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Template literals are preferred over string concatenation
 
-    const foo = 'bar'; console.log(foo + 'baz')
-                                   ^^^^^^^^^^^ 
+    console.log(1 + 'foo')
+                ^^^^^^^^^ 
 
   ℹ Recommended fix
 
-  - foo·+·'baz'
-  + `${foo}baz`
+  - 1·+·'foo'
+  + `${1}foo`
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -29,8 +29,7 @@
 ### `0: formatted`
 
 ```
-const foo = 'bar';
-console.log(`${foo}baz`);
+console.log(`${1}foo`);
 
 ```
 
@@ -42,13 +41,13 @@ console.log(`${foo}baz`);
 
   ✖ Template literals are preferred over string concatenation
 
-    console.log((1 * 2) + 'baz')
+    console.log((1 * 2) + 'foo')
                 ^^^^^^^^^^^^^^^ 
 
   ℹ Recommended fix
 
-  - (1 * 2)·+·'baz'
-  + `${1 * 2}baz`
+  - (1 * 2)·+·'foo'
+  + `${1 * 2}foo`
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -59,7 +58,7 @@ console.log(`${foo}baz`);
 ### `1: formatted`
 
 ```
-console.log(`${1 * 2}baz`);
+console.log(`${1 * 2}foo`);
 
 ```
 
@@ -67,17 +66,17 @@ console.log(`${1 * 2}baz`);
 
 ```
 
- unknown:1:49 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:12 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Template literals are preferred over string concatenation
 
-    const foo = 'bar'; const bar = 'foo' console.log(foo + 'baz' + bar + 'bam' + 'boo' + foo)
-                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    console.log(1 + 'foo' + 2 + 'bar' + 'baz' + 3)
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
   ℹ Recommended fix
 
-  - foo·+·'baz'·+·bar·+·'bam'·+·'boo'·+·foo
-  + `${foo}baz${bar}bamboo${foo}`
+  - 1·+·'foo'·+·2·+·'bar'·+·'baz'·+·3
+  + `${1}foo${2}barbaz${3}`
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -88,8 +87,148 @@ console.log(`${1 * 2}baz`);
 ### `2: formatted`
 
 ```
-const foo = 'bar';
-const bar = 'foo';
-console.log(`${foo}baz${bar}bamboo${foo}`);
+console.log(`${1}foo${2}barbaz${3}`);
+
+```
+
+### `3`
+
+```
+
+ unknown:1:13 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    console.log((1 + 'foo') * 2)
+                 ^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - 1·+·'foo'
+  + `${1}foo`
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `3: formatted`
+
+```
+console.log(`${1}foo` * 2);
+
+```
+
+### `4`
+
+```
+
+ unknown:1:12 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    console.log((1 * (2 + 'foo')) + 'bar')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - (1 * (2 + 'foo'))·+·'bar'
+  + `${1 * (2 + 'foo')}bar`
+
+ unknown:1:18 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    console.log((1 * (2 + 'foo')) + 'bar')
+                      ^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - 2·+·'foo'
+  + `${2}foo`
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 2 problems
+
+```
+
+### `4: formatted`
+
+```
+console.log(`${1 * `${2}foo`}bar`);
+
+```
+
+### `5`
+
+```
+✔ No known problems!
+
+```
+
+### `5: formatted`
+
+```
+console.log('foo' + 'bar');
+
+```
+
+### `6`
+
+```
+
+ unknown:1:12 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    console.log(`foo` + 1)
+                ^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - `foo`·+·1
+  + `foo${1}`
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `6: formatted`
+
+```
+console.log(`foo${1}`);
+
+```
+
+### `7`
+
+```
+
+ unknown:1:12 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    console.log('foo' + `bar${`baz${'bat' + 'bam'}`}` + 'boo')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - 'foo'·+·`bar${`baz${'bat' + 'bam'}`}`·+·'boo'
+  + `foobarbaz${'bat' + 'bam'}boo`
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `7: formatted`
+
+```
+console.log(`foobarbaz${'bat' + 'bam'}boo`);
 
 ```

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.md
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.md
@@ -62,3 +62,34 @@ console.log(`${foo}baz`);
 console.log(`${1 * 2}baz`);
 
 ```
+
+### `2`
+
+```
+
+ unknown:1:49 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    const foo = 'bar'; const bar = 'foo' console.log(foo + 'baz' + bar + 'bam' + 'boo' + foo)
+                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - foo·+·'baz'·+·bar·+·'bam'·+·'boo'·+·foo
+  + `${foo}baz${bar}bamboo${foo}`
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `2: formatted`
+
+```
+const foo = 'bar';
+const bar = 'foo';
+console.log(`${foo}baz${bar}bamboo${foo}`);
+
+```

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.md
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.md
@@ -232,3 +232,32 @@ console.log(`foo${1}`);
 console.log(`foobarbaz${'bat' + 'bam'}boo`);
 
 ```
+
+### `8`
+
+```
+
+ unknown:1:12 lint/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Template literals are preferred over string concatenation
+
+    console.log('foo' + 1 + 2)
+                ^^^^^^^^^^^^^ 
+
+  ℹ Recommended fix
+
+  - 'foo'·+·1·+·2
+  + `foo${1}${2}`
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `8: formatted`
+
+```
+console.log(`foo${1}${2}`);
+
+```

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.ts
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.ts
@@ -74,5 +74,13 @@ test(
         category: 'lint/preferTemplate',
       },
     );
+
+    await testLint(
+      t,
+      `console.log('foo' + 1 + 2)`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
   },
 );

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.ts
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.ts
@@ -26,5 +26,13 @@ test(
         category: 'lint/preferTemplate',
       },
     );
+
+    await testLint(
+      t,
+      `const foo = 'bar'; const bar = 'foo' console.log(foo + 'baz' + bar + 'bam' + 'boo' + foo)`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
   },
 );

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.ts
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.test.ts
@@ -13,7 +13,7 @@ test(
   async (t) => {
     await testLint(
       t,
-      `const foo = 'bar'; console.log(foo + 'baz')`,
+      `console.log(1 + 'foo')`,
       {
         category: 'lint/preferTemplate',
       },
@@ -21,7 +21,7 @@ test(
 
     await testLint(
       t,
-      `console.log((1 * 2) + 'baz')`,
+      `console.log((1 * 2) + 'foo')`,
       {
         category: 'lint/preferTemplate',
       },
@@ -29,7 +29,47 @@ test(
 
     await testLint(
       t,
-      `const foo = 'bar'; const bar = 'foo' console.log(foo + 'baz' + bar + 'bam' + 'boo' + foo)`,
+      `console.log(1 + 'foo' + 2 + 'bar' + 'baz' + 3)`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
+
+    await testLint(
+      t,
+      `console.log((1 + 'foo') * 2)`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
+
+    await testLint(
+      t,
+      `console.log((1 * (2 + 'foo')) + 'bar')`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
+
+    await testLint(
+      t,
+      `console.log('foo' + 'bar')`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
+
+    await testLint(
+      t,
+      `console.log(\`foo\` + 1)`,
+      {
+        category: 'lint/preferTemplate',
+      },
+    );
+
+    await testLint(
+      t,
+      `console.log('foo' + \`bar\${\`baz\${'bat' + 'bam'}\`}\` + 'boo')`,
       {
         category: 'lint/preferTemplate',
       },

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.ts
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.ts
@@ -5,81 +5,187 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Path} from '@romejs/js-compiler';
+import {Path, TransformExitResult} from '@romejs/js-compiler';
 import {
+  AnyExpression,
+  AnyNode,
+  BinaryExpression,
+  StringLiteral,
   TemplateLiteral,
+  stringLiteral,
   templateElement,
   templateLiteral,
 } from '@romejs/js-ast';
 import {descriptions} from '@romejs/diagnostics';
-import {TransformExitResult} from '@romejs/js-compiler/types';
-import {removeShallowLoc} from '@romejs/js-ast-utils';
+
+// expr + expr
+function isBinaryAddExpression(node: AnyNode): node is BinaryExpression {
+  return node.type === 'BinaryExpression' && node.operator === '+';
+}
+
+// 'str' + 'str'
+// 'str' + expr
+// expr + 'str'
+// expr + (expr + 'str')
+// (expr + 'str') + expr
+// expr * (expr + 'str')
+// (expr * expr) + 'str'
+function isUnnecessaryStringConcatExpression(
+  node: AnyNode,
+): node is BinaryExpression {
+  if (node.type !== 'BinaryExpression') {
+    return false;
+  }
+
+  if (node.left.type === 'BinaryExpression') {
+    if (isUnnecessaryStringConcatExpression(node.left)) {
+      return true;
+    }
+  }
+
+  if (node.right.type === 'BinaryExpression') {
+    if (isUnnecessaryStringConcatExpression(node.right)) {
+      return true;
+    }
+  }
+
+  if (!isBinaryAddExpression(node)) {
+    return false;
+  }
+
+  if (node.left.type === 'StringLiteral' && !node.left.value.includes('`')) {
+    return true;
+  }
+
+  if (node.right.type === 'StringLiteral' && !node.right.value.includes('`')) {
+    return true;
+  }
+
+  return false;
+}
+
+// expr + expr + expr + ...
+function collectBinaryAddExpressionExpressions(
+  node: BinaryExpression,
+): Array<AnyExpression> {
+  let expressions: Array<AnyExpression> = [];
+
+  if (isBinaryAddExpression(node.left)) {
+    expressions = expressions.concat(
+      collectBinaryAddExpressionExpressions(node.left),
+    );
+  } else {
+    expressions.push(node.left);
+  }
+
+  if (isBinaryAddExpression(node.right)) {
+    expressions = expressions.concat(
+      collectBinaryAddExpressionExpressions(node.right),
+    );
+  } else {
+    expressions.push(node.right);
+  }
+
+  return expressions;
+}
+
+// 'str' + 'str' + expr -> 'strstr' + expr
+function reduceBinaryExpressionExpressions(expressions: Array<AnyExpression>) {
+  let reducedExpressions: Array<AnyExpression> = [];
+  let index = 0;
+
+  while (index < expressions.length) {
+    let current = expressions[index];
+
+    if (current.type === 'StringLiteral') {
+      let strings: Array<StringLiteral> = [current];
+
+      while (index + 1 < expressions.length) {
+        let next = expressions[index + 1];
+        if (next.type === 'StringLiteral') {
+          strings.push(next);
+          index++;
+        } else {
+          break;
+        }
+      }
+
+      if (strings.length === 1) {
+        reducedExpressions.push(current);
+      } else {
+        reducedExpressions.push(
+          stringLiteral.create({
+            value: strings.map((string) => string.value).join(''),
+          }),
+        );
+      }
+    } else {
+      reducedExpressions.push(current);
+    }
+
+    index++;
+  }
+
+  return reducedExpressions;
+}
+
+// 'str' + expr + 'str' -> `str${expr}str`
+function convertExpressionsToTemplateLiteral(
+  items: Array<AnyExpression>,
+): TemplateLiteral {
+  let expressions = [];
+  let quasis = [];
+
+  for (let index = 0; index < items.length; index++) {
+    let item = items[index];
+    let isTail = index === items.length - 1;
+    let isHead = index === 0;
+
+    if (item.type === 'StringLiteral') {
+      quasis.push(
+        templateElement.create({
+          cooked: item.value,
+          raw: item.value,
+          tail: isTail,
+        }),
+      );
+    } else {
+      expressions.push(item);
+      if (isTail || isHead) {
+        quasis.push(
+          templateElement.create({
+            cooked: '',
+            raw: '',
+            tail: isTail,
+          }),
+        );
+      }
+    }
+  }
+
+  return templateLiteral.create({
+    expressions,
+    quasis,
+  });
+}
 
 export default {
   name: 'preferTemplate',
   enter(path: Path): TransformExitResult {
     const {node} = path;
 
-    if (
-      node.type === 'BinaryExpression' &&
-      node.operator === '+' &&
-      ((node.left.type === 'StringLiteral' && !node.left.value.includes('`')) ||
-      (node.right.type === 'StringLiteral' && !node.right.value.includes('`')))
-    ) {
-      let autofix: undefined | TemplateLiteral;
+    if (isUnnecessaryStringConcatExpression(node)) {
+      let expressions = collectBinaryAddExpressionExpressions(node);
+      let reducedExpressions = reduceBinaryExpressionExpressions(expressions);
+      let template = convertExpressionsToTemplateLiteral(reducedExpressions);
 
-      if (node.right.type === 'StringLiteral') {
-        const quasis = [
-          templateElement.create({
-            raw: '',
-            cooked: '',
-          }),
-          templateElement.create({
-            raw: node.right.value,
-            cooked: node.right.value,
-          }),
-        ];
-        const expressions = [removeShallowLoc(node.left)];
-        autofix = templateLiteral.create({
-          expressions,
-          quasis,
-          loc: node.loc,
-        });
-      }
-
-      if (node.left.type === 'StringLiteral') {
-        const quasis = [
-          templateElement.create({
-            raw: node.left.value,
-            cooked: node.left.value,
-          }),
-          templateElement.create({
-            raw: '',
-            cooked: '',
-          }),
-        ];
-
-        // We need to remove the location or else if we were to show a preview the source map would resolve to the end of
-        // this node
-        const expressions = [removeShallowLoc(node.right)];
-        autofix = templateLiteral.create({
-          expressions,
-          quasis,
-          loc: node.loc,
-        });
-      }
-
-      if (autofix === undefined) {
-        path.context.addNodeDiagnostic(node, descriptions.LINT.PREFER_TEMPLATE);
-      } else {
-        return path.context.addFixableDiagnostic(
-          {
-            old: node,
-            fixed: autofix,
-          },
-          descriptions.LINT.PREFER_TEMPLATE,
-        );
-      }
+      return path.context.addFixableDiagnostic(
+        {
+          old: node,
+          fixed: template,
+        },
+        descriptions.LINT.PREFER_TEMPLATE,
+      );
     }
 
     return node;

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.ts
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.ts
@@ -182,7 +182,7 @@ function createEmptyQuasis(isTail: boolean = false) {
     cooked: '',
     raw: '',
     tail: isTail,
-  })
+  });
 }
 
 // 'str' + expr + 'str' -> `str${expr}str`
@@ -210,8 +210,9 @@ function convertTemplatePartsToTemplateLiteral(
     } else {
       templateExpressions.push(node);
 
-      let next = nodes[index + 1]
-      let isNextQuasis = next?.type === 'StringLiteral' || next?.type === 'TemplateElement'
+      let next = nodes[index + 1];
+      let isNextQuasis =
+        next?.type === 'StringLiteral' || next?.type === 'TemplateElement';
 
       if (isTail || isHead || !isNextQuasis) {
         templateQuasis.push(createEmptyQuasis(isTail));

--- a/packages/@romejs/js-compiler/lint/rules/preferTemplate.ts
+++ b/packages/@romejs/js-compiler/lint/rules/preferTemplate.ts
@@ -177,6 +177,14 @@ function combineTemplateParts(expressions: Array<TemplatePart>) {
   return reducedExpressions;
 }
 
+function createEmptyQuasis(isTail: boolean = false) {
+  return templateElement.create({
+    cooked: '',
+    raw: '',
+    tail: isTail,
+  })
+}
+
 // 'str' + expr + 'str' -> `str${expr}str`
 function convertTemplatePartsToTemplateLiteral(
   nodes: Array<TemplatePart>,
@@ -190,7 +198,7 @@ function convertTemplatePartsToTemplateLiteral(
     let isHead = index === 0;
 
     if (node.type === 'TemplateElement') {
-      templateElement;
+      templateQuasis.push(node);
     } else if (node.type === 'StringLiteral') {
       templateQuasis.push(
         templateElement.create({
@@ -201,14 +209,12 @@ function convertTemplatePartsToTemplateLiteral(
       );
     } else {
       templateExpressions.push(node);
-      if (isTail || isHead) {
-        templateQuasis.push(
-          templateElement.create({
-            cooked: '',
-            raw: '',
-            tail: isTail,
-          }),
-        );
+
+      let next = nodes[index + 1]
+      let isNextQuasis = next?.type === 'StringLiteral' || next?.type === 'TemplateElement'
+
+      if (isTail || isHead || !isNextQuasis) {
+        templateQuasis.push(createEmptyQuasis(isTail));
       }
     }
   }

--- a/packages/@romejs/pretty-format/index.ts
+++ b/packages/@romejs/pretty-format/index.ts
@@ -168,7 +168,7 @@ function formatFunction(val: Function, opts: FormatOptions): string {
   let label = `Function ${name}`;
 
   if (isNativeFunction(val)) {
-    label = `Native` + label;
+    label = `Native${label}`;
   }
 
   if (Object.keys(val).length === 0) {

--- a/packages/@romejs/string-markup/ansi.ts
+++ b/packages/@romejs/string-markup/ansi.ts
@@ -42,11 +42,9 @@ export const formatAnsi = {
       b: number;
     },
   ): string {
-    return (
-      `\u001b[38;2;${String(color.r)};${String(color.g)};${String(color.b)}m` +
-      str +
-      createEscape(39)
-    );
+    return `\u001b[38;2;${String(color.r)};${String(color.g)};${String(color.b)}m${str}${createEscape(
+      39,
+    )}`;
   },
   bgRgb(
     str: string,
@@ -56,11 +54,9 @@ export const formatAnsi = {
       b: number;
     },
   ): string {
-    return (
-      `\u001b[48;2;${String(color.r)};${String(color.g)};${String(color.b)}m` +
-      str +
-      createEscape(49)
-    );
+    return `\u001b[48;2;${String(color.r)};${String(color.g)};${String(color.b)}m${str}${createEscape(
+      49,
+    )}`;
   },
   bold(str: string): string {
     return createEscape(1) + str + createEscape(22);

--- a/scripts/ast/update.cjs
+++ b/scripts/ast/update.cjs
@@ -88,10 +88,7 @@ readIndexFile(
   [
     {
       iterator({category, nodeType}) {
-        return (
-          `import ${nodeType} from './${category}/${nodeType}';\n` +
-          `builders.set('${nodeType}', ${nodeType});\n\n`
-        );
+        return `import ${nodeType} from './${category}/${nodeType}';\nbuilders.set('${nodeType}', ${nodeType});\n\n`;
       },
     },
   ],
@@ -103,10 +100,7 @@ readIndexFile(
   [
     {
       iterator({category, nodeType}) {
-        return (
-          `import ${nodeType} from './${category}/${nodeType}';\n` +
-          `evaluators.set('${nodeType}', ${nodeType});\n\n`
-        );
+        return `import ${nodeType} from './${category}/${nodeType}';\nevaluators.set('${nodeType}', ${nodeType});\n\n`;
       },
     },
   ],


### PR DESCRIPTION
Currently broken because of the `scope.getBinding()` issue I mentioned.


Autofix:

```js
// before:
a + "b" + c + "d"
// after:
`${a}b${c}d`
```