### PR TITLE
fs: improve readdir/readdirSync performance

### DIFF
--- a/packages/@romejs/fs/index.ts
+++ b/packages/@romejs/fs/index.ts
@@ -110,7 +110,7 @@ function createReaddirReturn(
       ext: path.memoizedExtension,
       filename: path.memoizedFilename,
       isFile: basename.isFile(),
-      isDirectory: basename.isDirectory()
+      isDirectory: basename.isDirectory(),
     });
   }));
 }

--- a/packages/@romejs/fs/index.ts
+++ b/packages/@romejs/fs/index.ts
@@ -102,16 +102,22 @@ export function writeFileSync(
 // readdir
 function createReaddirReturn(
   folder: AbsoluteFilePath,
-  files: Array<string>,
+  files: Array<fs.Dirent>,
 ): AbsoluteFilePathSet {
   return new AbsoluteFilePathSet(files.map((basename) => {
-    return folder.append(basename);
+    const path = folder.append(basename.name);
+    return new AbsoluteFilePath(path.getParsed(), {
+      ext: path.memoizedExtension,
+      filename: path.memoizedFilename,
+      isFile: basename.isFile(),
+      isDirectory: basename.isDirectory()
+    });
   }));
 }
 
 export function readdir(path: AbsoluteFilePath): Promise<AbsoluteFilePathSet> {
   return new Promise((resolve, reject) => {
-    fs.readdir(path.join(), (err, files) => {
+    fs.readdir(path.join(), {withFileTypes: true}, (err, files) => {
       if (err === null) {
         resolve(createReaddirReturn(path, files));
       } else {
@@ -122,7 +128,9 @@ export function readdir(path: AbsoluteFilePath): Promise<AbsoluteFilePathSet> {
 }
 
 export function readdirSync(path: AbsoluteFilePath): AbsoluteFilePathSet {
-  return createReaddirReturn(path, fs.readdirSync(path.join()));
+  return createReaddirReturn(path, fs.readdirSync(path.join(), {
+    withFileTypes: true,
+  }));
 }
 
 // lstat

--- a/packages/@romejs/path/index.ts
+++ b/packages/@romejs/path/index.ts
@@ -11,6 +11,8 @@ type FilePathOptions<Super> = {
   filename?: string;
   ext?: string;
   parent?: Super;
+  isDirectory?: boolean;
+  isFile?: boolean;
 };
 
 type FilePathOrString = string | UnknownFilePath;
@@ -39,6 +41,9 @@ class BaseFilePath<Super extends UnknownFilePath> {
     this.absoluteTarget = parsed.absoluteTarget;
     this.absoluteType = parsed.absoluteType;
 
+    this.isDirectory = opts.isDirectory;
+    this.isFile = opts.isFile;
+
     // Memoized
     this.memoizedUnique = undefined;
     this.memoizedParent = opts.parent;
@@ -59,6 +64,9 @@ class BaseFilePath<Super extends UnknownFilePath> {
 
   absoluteType: ParsedPathAbsoluteType;
   absoluteTarget: undefined | string;
+
+  isDirectory: undefined | boolean;
+  isFile: undefined | boolean;
 
   getParsed(): ParsedPath {
     return {

--- a/packages/@romejs/project/load.ts
+++ b/packages/@romejs/project/load.ts
@@ -30,7 +30,7 @@ import {
 import {ConsumeJSONResult, consumeJSONExtra} from '@romejs/codec-json';
 import {AbsoluteFilePath, AbsoluteFilePathSet} from '@romejs/path';
 import {ob1Add, ob1Coerce1, ob1Inc, ob1Number0} from '@romejs/ob1';
-import {existsSync, lstatSync, readFileTextSync, readdirSync} from '@romejs/fs';
+import {existsSync, readFileTextSync, readdirSync} from '@romejs/fs';
 import crypto = require('crypto');
 
 import {ROME_CONFIG_PACKAGE_JSON_FIELD} from './constants';
@@ -419,10 +419,9 @@ function normalizeTypeCheckingLibs(
   for (const folder of folders) {
     const files = readdirSync(folder);
     for (const file of files) {
-      const stats = lstatSync(file);
-      if (stats.isFile()) {
+      if (file.isFile) {
         libFiles.add(file);
-      } else if (stats.isDirectory()) {
+      } else if (file.isDirectory) {
         folders.push(file);
       }
     }

--- a/scripts/_utils.cjs
+++ b/scripts/_utils.cjs
@@ -19,7 +19,11 @@ exports.unlink = function(loc, isFile, isDirectory) {
     fs.unlinkSync(loc);
   } else if (isDirectory) {
     for (const filename of fs.readdirSync(loc, {withFileTypes: true})) {
-      exports.unlink(path.join(loc, filename.name), filename.isFile(), filename.isDirectory());
+      exports.unlink(
+        path.join(loc, filename.name),
+        filename.isFile(),
+        filename.isDirectory(),
+      );
     }
     fs.rmdirSync(loc);
   }

--- a/scripts/_utils.cjs
+++ b/scripts/_utils.cjs
@@ -10,17 +10,16 @@ const child = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
-exports.unlink = function(loc) {
+exports.unlink = function(loc, isFile, isDirectory) {
   if (!fs.existsSync(loc)) {
     return;
   }
 
-  const stats = fs.lstatSync(loc);
-  if (stats.isFile()) {
+  if (isFile) {
     fs.unlinkSync(loc);
-  } else if (stats.isDirectory()) {
-    for (const filename of fs.readdirSync(loc)) {
-      exports.unlink(path.join(loc, filename));
+  } else if (isDirectory) {
+    for (const filename of fs.readdirSync(loc, {withFileTypes: true})) {
+      exports.unlink(path.join(loc, filename.name), filename.isFile(), filename.isDirectory());
     }
     fs.rmdirSync(loc);
   }
@@ -70,7 +69,7 @@ exports.execDev = function(argv) {
 };
 
 exports.buildTrunk = function() {
-  exports.unlink(devFolder);
+  exports.unlink(devFolder, false, true);
   fs.mkdirSync(devFolder);
 
   console.log(exports.inverse('Building trunk'));

--- a/scripts/commit-rome
+++ b/scripts/commit-rome
@@ -26,4 +26,4 @@ fs.copyFileSync(
   `${VENDOR_ROME}.map`,
 );
 
-unlink(TEMP_DIR);
+unlink(TEMP_DIR, false, true);


### PR DESCRIPTION
This is a minor optimization to use `withFileTypes` with `fs.readdir`. This will allow us to avoid an extra call to `lstat` when we want to operate on a directory.