### PR TITLE
feat: clean dist before building trunk

### DIFF
--- a/scripts/_constants.cjs
+++ b/scripts/_constants.cjs
@@ -9,6 +9,7 @@ const path = require('path');
 const os = require('os');
 
 exports.devFolder = path.join(os.tmpdir(), 'rome-dev');
+exports.distFolder = path.join(__dirname, '..', 'dist');
 exports.root = path.join(__dirname, '..');
 exports.packages = path.join(exports.root, 'packages', '@romejs');
 exports.formatterFolder = path.join(

--- a/scripts/_utils.cjs
+++ b/scripts/_utils.cjs
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {root, devFolder} = require('./_constants.cjs');
+const {root, devFolder, distFolder} = require('./_constants.cjs');
 const child = require('child_process');
 const path = require('path');
 const fs = require('fs');
@@ -77,6 +77,7 @@ exports.execDev = function(argv) {
 };
 
 exports.buildTrunk = function() {
+  exports.unlink(distFolder);
   exports.unlink(devFolder);
   fs.mkdirSync(devFolder);
 


### PR DESCRIPTION
This pull request updates the CLI so that the `dist` directory is cleaned before building the project trunk. This mitigates potential confusion for users who follow the user-specific [installation instructions](https://romejs.dev/docs/introduction/installation/#cloning-and-building) followed by the contributor-specific [getting started](https://github.com/romejs/rome/blob/master/.github/CONTRIBUTING.md#getting-started) instructions, which results in two `package.json` files and a duplicate package name warning for `rome`.

This scenario will become more uncommon once Rome is distributed via package managers and no longer requires cloning, but it feels like resilient trunk building should be in place regardless.

Resolves #404