### PR TITLE
fix: clarify contributor installation instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,8 @@ cd rome
 ./scripts/dev-rome --help
 ```
 
+**Note:** If you previously ran the user-facing [installation instructions](https://romejs.dev/docs/introduction/installation), the `dist` directory must be deleted before running any development commands.
+
 No dependency installation step is required as we check in our `node_modules` folder that contains only a copy of TypeScript and some definitions.
 
 Refer to [Getting Started](https://romejs.dev/docs/introduction/getting-started/) for more usage documentation.

--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -18,6 +18,8 @@ cd rome
 scripts/dev-rome --help
 ```
 
+> Note: If you previously ran the user-facing [installation instructions](../introduction/installation), the `dist` directory must be deleted before running any development commands.
+
 No dependency installation step is required as we check in our `node_modules` folder that contains only a copy of TypeScript and some definitions.
 
 Refer to [Getting Started](../introduction/getting-started.md) for more usage documentation.


### PR DESCRIPTION
This pull request updates contributor installation instructions by clarifying that the `dist` directory should be removed before running any development commands. This mitigates potential confusion for users who follow the user-specific [installation instructions](https://romejs.dev/docs/introduction/installation/#cloning-and-building) followed by the contributor-specific [getting started](https://github.com/romejs/rome/blob/master/.github/CONTRIBUTING.md#getting-started) instructions, which results in two `package.json` files and a duplicate package name warning for `rome`.

Resolves #404