### PR TITLE
Better tab support in buildMessageCodeFrame

### DIFF
--- a/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
@@ -27,7 +27,7 @@ import {
   markup,
   markupToPlainTextString,
 } from '@romejs/string-markup';
-import {toLines} from './utils';
+import {ToLines, toLines} from './utils';
 import printAdvice from './printAdvice';
 import {default as successBanner} from './banners/success.json';
 import {default as errorBanner} from './banners/error.json';
@@ -116,7 +116,7 @@ type FileDependency = ChangeFileDependency | ReferenceFileDependency;
 
 export type DiagnosticsPrinterFileSources = UnknownFilePathMap<{
   sourceText: string;
-  lines: Array<string>;
+  lines: ToLines;
 }>;
 
 export type DiagnosticsPrinterFileMtimes = UnknownFilePathMap<number>;

--- a/packages/@romejs/cli-diagnostics/buildPatchCodeFrame.ts
+++ b/packages/@romejs/cli-diagnostics/buildPatchCodeFrame.ts
@@ -11,7 +11,7 @@ import {
   GUTTER,
   MAX_PATCH_LINES,
 } from './constants';
-import {joinNoBreak, showInvisibles} from './utils';
+import {joinNoBreak, normalizeTabs, showInvisibles} from './utils';
 import {Diffs, diffConstants, groupDiffByLines} from '@romejs/string-diff';
 import {escapeMarkup, markup, markupTag} from '@romejs/string-markup';
 import {DiagnosticAdviceDiff} from '@romejs/diagnostics';
@@ -24,7 +24,7 @@ function formatDiffLine(diffs: Diffs) {
       return markupTag('success', escapeMarkup(showInvisibles(text)));
     } else {
       // type === diffConstants.EQUAL
-      return escapeMarkup(text);
+      return escapeMarkup(normalizeTabs(text));
     }
   }).join('');
 }

--- a/packages/@romejs/cli-diagnostics/constants.ts
+++ b/packages/@romejs/cli-diagnostics/constants.ts
@@ -8,7 +8,6 @@
 export const GUTTER = ' \u2502 ';
 export const CODE_FRAME_INDENT = '  ';
 export const CODE_FRAME_SELECTED_INDENT = `<error>\></error> `;
-export const FILENAME_INDENT = '  ';
 
 export const MAX_CODE_FRAME_LINES = 8;
 export const HALF_MAX_CODE_FRAME_LINES = MAX_CODE_FRAME_LINES / 2;

--- a/packages/@romejs/cli-diagnostics/printAdvice.ts
+++ b/packages/@romejs/cli-diagnostics/printAdvice.ts
@@ -21,7 +21,7 @@ import {
   diagnosticLocationToMarkupFilelink,
 } from '@romejs/diagnostics';
 import {Position} from '@romejs/parser-core';
-import {showInvisibles, toLines} from './utils';
+import {ToLines, showInvisibles, toLines} from './utils';
 import buildPatchCodeFrame from './buildPatchCodeFrame';
 import buildMessageCodeFrame from './buildMessageCodeFrame';
 import {escapeMarkup, markupTag} from '@romejs/string-markup';
@@ -289,7 +289,11 @@ function printFrame(
     cleanMarker = markupTag('emphasis', cleanMessage(marker));
   }
 
-  let lines: Array<string> = [];
+  let lines: ToLines = {
+    length: 0,
+    raw: [],
+    highlighted: [],
+  };
   if (sourceText !== undefined) {
     lines = toLines({
       path,
@@ -307,7 +311,11 @@ function printFrame(
     path.isAbsolute() &&
     opts.missingFileSources.has(path.assertAbsolute())
   ) {
-    lines = ['<dim>File does not exist</dim>'];
+    lines = {
+      length: 1,
+      raw: ['File does not exist'],
+      highlighted: ['<dim>File does not exist</dim>'],
+    };
   }
 
   if (sourceText === undefined) {

--- a/packages/@romejs/cli-diagnostics/utils.ts
+++ b/packages/@romejs/cli-diagnostics/utils.ts
@@ -9,6 +9,10 @@ import {markupToPlainTextString} from '@romejs/string-markup';
 import highlightCode, {AnsiHighlightOptions} from './highlightCode';
 import {NEWLINE} from '@romejs/js-parser-utils';
 
+export function normalizeTabs(str: string): string {
+  return str.replace(/\t/g, '  ');
+}
+
 export function showInvisibles(str: string): string {
   let ret = '';
   for (const cha of str) {
@@ -61,8 +65,25 @@ export function splitLines(src: string): Array<string> {
   return src.replace(/\t/g, ' ').split(NEWLINE);
 }
 
-export function toLines(opts: AnsiHighlightOptions): Array<string> {
-  const highlighted = highlightCode(opts);
-  const lines = splitLines(highlighted);
-  return lines;
+export type ToLines = {
+  length: number;
+  raw: Array<string>;
+  highlighted: Array<string>;
+};
+
+export function toLines(opts: AnsiHighlightOptions): ToLines {
+  const raw = splitLines(opts.input);
+  const highlighted = splitLines(highlightCode(opts));
+
+  if (raw.length !== highlighted.length) {
+    throw new Error(
+      `raw and highlighted line count mismatch ${raw.length} !== ${highlighted.length}`,
+    );
+  }
+
+  return {
+    length: raw.length,
+    raw,
+    highlighted,
+  };
 }

--- a/packages/@romejs/core/test-worker/TestAPI.ts
+++ b/packages/@romejs/core/test-worker/TestAPI.ts
@@ -10,7 +10,6 @@ import {
   DiagnosticAdvice,
   createBlessedDiagnosticMessage,
   createSingleDiagnosticError,
-  deriveDiagnosticFromError,
   deriveDiagnosticFromErrorStructure,
   descriptions,
   getErrorStackAdvice,
@@ -608,7 +607,7 @@ export default class TestAPI implements TestHelper {
 
       if (status === 'UPDATE' && this.options.freezeSnapshots) {
         await this.emitDiagnostic(
-          deriveDiagnosticFromError(
+          deriveDiagnosticFromErrorStructure(
             callError,
             {
               description: descriptions.SNAPSHOTS.INLINE_FROZEN,
@@ -619,7 +618,7 @@ export default class TestAPI implements TestHelper {
 
       if (status === 'NO_MATCH') {
         await this.emitDiagnostic(
-          deriveDiagnosticFromError(
+          deriveDiagnosticFromErrorStructure(
             callError,
             {
               description: {
@@ -698,7 +697,7 @@ export default class TestAPI implements TestHelper {
       if (existingSnapshot === undefined) {
         if (this.options.freezeSnapshots) {
           await this.emitDiagnostic(
-            deriveDiagnosticFromError(
+            deriveDiagnosticFromErrorStructure(
               callError,
               {
                 description: descriptions.SNAPSHOTS.FROZEN,
@@ -748,7 +747,7 @@ export default class TestAPI implements TestHelper {
         });
 
         await this.emitDiagnostic(
-          deriveDiagnosticFromError(
+          deriveDiagnosticFromErrorStructure(
             callError,
             {
               description: {

--- a/packages/@romejs/diagnostics/derive.ts
+++ b/packages/@romejs/diagnostics/derive.ts
@@ -224,11 +224,17 @@ export function getErrorStackAdvice(
     if (cleanStack.startsWith(removeMessage)) {
       cleanStack = cleanStack.slice(removeMessage.length);
     }
+    cleanStack = cleanStack.trim();
 
     advice.push({
       type: 'log',
-      category: 'error',
-      text: escapeMarkup(cleanStack),
+      category: 'warn',
+      text: 'Raw stack trace is being displayed as we did not receive any frames',
+    });
+
+    advice.push({
+      type: 'list',
+      list: cleanStack.split('\n').map((line) => escapeMarkup(line.trim())),
     });
   } else {
     const adviceFrames = frames.map((frame) => {

--- a/packages/@romejs/v8/sourceMapManager.ts
+++ b/packages/@romejs/v8/sourceMapManager.ts
@@ -78,7 +78,7 @@ function buildStackString(err: Error): string {
       parts.push('new');
     }
 
-    let name = '<anonymous';
+    let name = '<anonymous>';
     if (functionName !== undefined) {
       name = functionName;
     }


### PR DESCRIPTION
This adds better tab support to `buildMessageCodeFrame`. Hard tabs are displayed as two soft spaced tabs. Maybe we could possibly allow configuration but I would rather avoid it. This is necessary so we can switch to hard tabs in the formatter.

#425