### PR TITLE
Fast path for single part matching in doesNodeMatchPattern

### DIFF
--- a/packages/@romejs/js-ast-utils/doesNodeMatchPattern.ts
+++ b/packages/@romejs/js-ast-utils/doesNodeMatchPattern.ts
@@ -52,6 +52,11 @@ export default function doesNodeMatchPattern(
 
 	const {parts: expectedParts, hasDoubleStar} = split(match);
 
+	// Fast path for single part pattern matching
+	if (expectedParts.length && expectedParts[0] !== '*' && !hasDoubleStar) {
+		return isIdentifierish(node) && node.name === expectedParts[0];
+	}
+
 	const {bailed, parts: actualParts} = getNodeReferenceParts(node);
 
 	// Bailed will be true if we were unable to derive a name for one of the parts


### PR DESCRIPTION
This allows `doesNodeMatchPattern` to be used with single parts and have comparable performance to checking `name` yourself except that you can pass around patterns.