### PR TITLE
Update .editorconfig with correct extensions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,6 @@ end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.js]
+[{*.ts,*.json}]
 indent_style = tab
 indent_size = 2


### PR DESCRIPTION
This is a holdout from when Rome was written with Flow and used the `.js` extension.

Thanks @RReverser for noticing! https://twitter.com/RReverser/status/1261841111498326021