### PR TITLE
Add hasDiagnostics and fix CLI exit code

### DIFF
--- a/packages/@romejs/cli/cli.ts
+++ b/packages/@romejs/cli/cli.ts
@@ -484,7 +484,7 @@ export default async function cli() {
 		}
 
 		case "DIAGNOSTICS": {
-			process.exit(res.diagnostics.length === 0 ? 0 : 1);
+			process.exit(res.hasDiagnostics ? 1 : 0);
 			break;
 		}
 

--- a/packages/@romejs/core/common/bridges/MasterBridge.ts
+++ b/packages/@romejs/core/common/bridges/MasterBridge.ts
@@ -54,6 +54,7 @@ export type MasterQueryResponseError = {
 
 export type MasterQueryResponseDiagnostics = {
 	type: "DIAGNOSTICS";
+	hasDiagnostics: boolean;
 	diagnostics: Diagnostics;
 };
 

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -901,6 +901,7 @@ export default class Master {
 			} else {
 				return {
 					type: "DIAGNOSTICS",
+					hasDiagnostics: diagnostics.length > 0,
 					diagnostics,
 				};
 			}

--- a/packages/@romejs/core/master/MasterRequest.ts
+++ b/packages/@romejs/core/master/MasterRequest.ts
@@ -254,6 +254,7 @@ export default class MasterRequest {
 				} else if (res.type === "DIAGNOSTICS") {
 					res = {
 						type: "DIAGNOSTICS",
+						hasDiagnostics: res.hasDiagnostics,
 						diagnostics: [],
 					};
 				} else if (res.type === "INVALID_REQUEST") {


### PR DESCRIPTION
Right now when there are lint or test failures we do not emit the correct exit code. This causes GitHub actions to pass when they should not.

What's happening here is that the CLI is passing `noData` to the server. This is to save on bridge transport in daemon mode because the CLI doesn't care about the request return values. This also causes `diagnostics` to be set to an empty array.

So to correct this there's a separate `hasDiagnostics` property that will always be correct.