### PR TITLE
fix: camel case generated lint rule names

### DIFF
--- a/scripts/_utils.cjs
+++ b/scripts/_utils.cjs
@@ -102,3 +102,28 @@ exports.readGeneratedFile = function(loc) {
 	file += "\n\n";
 	return file;
 };
+
+exports.toCamelCase = function(str, forceCapitalize) {
+	if (str.length === 0) {
+		return str;
+	}
+
+	// Prepend uppercase letters with a space
+	str = str.replace(/([A-Z+])/g, " $1");
+
+	// We no longer care about the casing
+	str = str.toLowerCase();
+
+	// Capitalize all characters after a symbol or space
+	str = str.replace(/[_.\- ]+(\w|$)/g, (_, p1) => p1.toUpperCase());
+
+	// Capitalize characters after a number
+	str = str.replace(/\d+(\w|$)/g, (m) => m.toUpperCase());
+
+	// Force capitalize if necessary
+	if (forceCapitalize) {
+		str = str[0].toUpperCase() + str.slice(1);
+	}
+
+	return str;
+};

--- a/scripts/lint/add.cjs
+++ b/scripts/lint/add.cjs
@@ -7,7 +7,7 @@
 
 require("../_setup.cjs");
 
-const {write} = require("../_utils.cjs");
+const {toCamelCase, write} = require("../_utils.cjs");
 const {lintRulesFolder, descriptionsFile} = require("../_constants.cjs");
 const path = require("path");
 const fs = require("fs");
@@ -19,12 +19,17 @@ if (ruleName === undefined || category === undefined) {
 	process.exit(1);
 }
 
-const spacedName = ruleName.replace(/([A-Z+])/g, " $1").trim().toLowerCase();
+const camelCasedName = toCamelCase(ruleName);
+const spacedName = camelCasedName.replace(/([A-Z+])/g, " $1").trim().toLowerCase();
 const descriptionKey = spacedName.toUpperCase().replace(/ /g, "_");
-const categoryName = `lint/${ruleName}`;
+const categoryName = `lint/${camelCasedName}`;
 
-const ruleLoc = path.join(lintRulesFolder, category, `${ruleName}.ts`);
-const testLoc = path.join(lintRulesFolder, category, `${ruleName}.test.ts`);
+const ruleLoc = path.join(lintRulesFolder, category, `${camelCasedName}.ts`);
+const testLoc = path.join(
+	lintRulesFolder,
+	category,
+	`${camelCasedName}.test.ts`,
+);
 
 write(
 	ruleLoc,
@@ -32,7 +37,7 @@ write(
 import {descriptions} from "@romejs/diagnostics";
 
 export default {
- name: "${ruleName}",
+ name: "${camelCasedName}",
  enter(path: Path): TransformExitResult {
 	 const {node} = path;
 


### PR DESCRIPTION
This pull request updates the generation script for adding new lint rules by camel casing generated filenames in the same way that internal linting does.

Resolves #456