### PR TITLE
wrap emphasis in the message of noDidUpdateSetState

### DIFF
--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -294,7 +294,7 @@ export const descriptions = createMessages({
 	LINT: {
 		NO_DID_UPDATE_SET_STATE: {
 			category: "lint/noDidUpdateSetState",
-			message: "Avoid this.setState in componentDidUpdate",
+			message: "Avoid <emphasis>this.setState</emphasis> in <emphasis>componentDidUpdate</emphasis>",
 		},
 		JSX_A11Y_HEADING_HAS_CONTENT: {
 			category: "lint/jsxA11yHeadingHasContent",


### PR DESCRIPTION
small update from a comment in https://github.com/romejs/rome/pull/472#discussion_r426724266. @bitpshr 

Since you pointed that out, I figure I would make this update to this rule message as well.