### PR TITLE
Add jsxA11yLang suggestions

### DIFF
--- a/packages/@romejs/cli-diagnostics/printAdvice.ts
+++ b/packages/@romejs/cli-diagnostics/printAdvice.ts
@@ -228,7 +228,7 @@ function printList(
 		const {truncated} = opts.reporter.list(
 			item.list,
 			{
-				truncate: opts.flags.verboseDiagnostics ? undefined : 20,
+				truncate: opts.flags.verboseDiagnostics ? undefined : 10,
 				reverse: item.reverse,
 				ordered: item.ordered,
 			},

--- a/packages/@romejs/diagnostics/descriptions.ts
+++ b/packages/@romejs/diagnostics/descriptions.ts
@@ -300,10 +300,11 @@ export const descriptions = createMessages({
 			category: "lint/jsxA11yAnchorHasContent",
 			message: "Anchor must have content and the content must be accessible by a screen reader.",
 		},
-		JSX_A11Y_HTML_INVALID_LANG: {
+		JSX_A11Y_HTML_INVALID_LANG: (value: string, suggestions: Array<string>) => ({
 			category: "lint/jsxA11yLang",
 			message: `The <emphasis>lang</emphasis> attribute must have a valid value.`,
-		},
+			advice: buildSuggestionAdvice(value, suggestions),
+		}),
 		NO_DID_UPDATE_SET_STATE: {
 			category: "lint/noDidUpdateSetState",
 			message: "Avoid <emphasis>this.setState</emphasis> in <emphasis>componentDidUpdate</emphasis>",

--- a/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.test.md
+++ b/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.test.md
@@ -87,8 +87,28 @@
     <html lang="aa-zz"></html>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+  ℹ Did you mean aa-AF?
+
+  - aa-zz
+  + aa-AF
+
+  ℹ Or one of these?
+
+  - aa-AL
+  - aa-DZ
+  - aa-AS
+  - aa-AD
+  - aa-AO
+  - aa-AI
+  - aa-AQ
+  - aa-AG
+  - aa-AR
+  - aa-AM
+  and 222 others...
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+⚠ Some diagnostics have been truncated. Use the --verbose-diagnostics flag to disable truncation.
 ✖ Found 1 problem
 
 ```
@@ -111,8 +131,28 @@
     <html lang="zz-AA"></html>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+  ℹ Did you mean az-AF?
+
+  - zz-AA
+  + az-AF
+
+  ℹ Or one of these?
+
+  - az-AL
+  - az-AS
+  - az-AD
+  - az-AO
+  - az-AI
+  - az-AQ
+  - az-AG
+  - az-AR
+  - az-AM
+  - az-AW
+  and 37 others...
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+⚠ Some diagnostics have been truncated. Use the --verbose-diagnostics flag to disable truncation.
 ✖ Found 1 problem
 
 ```
@@ -127,18 +167,42 @@
 ### `5`
 
 ```
-✔ No known problems!
+
+ unknown:1 lint/jsxA11yLang ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ The lang attribute must have a valid value.
+
+    <html lang="en2></html>
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
 
 ```
 
 ### `5: formatted`
 
 ```
-<html lang='en-US'></html>;
+<html lang='en2&gt;&lt;/html&gt;'></html>;
 
 ```
 
 ### `6`
+
+```
+✔ No known problems!
+
+```
+
+### `6: formatted`
+
+```
+<html lang='en-US'></html>;
+
+```
+
+### `7`
 
 ```
 
@@ -155,21 +219,21 @@
 
 ```
 
-### `6: formatted`
+### `7: formatted`
 
 ```
 <html lang='en'></html>;
 
 ```
 
-### `7`
+### `8`
 
 ```
 ✔ No known problems!
 
 ```
 
-### `7: formatted`
+### `8: formatted`
 
 ```
 <html lang={lang}></html>;

--- a/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.test.ts
+++ b/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.test.ts
@@ -13,6 +13,7 @@ test(
 				'<html lang="foo-bar"></html>',
 				'<html lang="aa-zz"></html>',
 				'<html lang="zz-AA"></html>',
+				'<html lang="en2></html>',
 				// VALID
 				'<html lang="en-US"></html>',
 				'<html lang="en"></html>',

--- a/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.ts
+++ b/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.ts
@@ -398,8 +398,13 @@ const ISO = {
 };
 
 // We lazily build this suggestions list as it is massive
+let suggestions: undefined | Array<string>;
 function getSuggestions() {
-	const suggestions = [...ISO.countries];
+	if (suggestions !== undefined) {
+		return suggestions;
+	}
+
+	suggestions = [...ISO.countries];
 
 	for (const language of ISO.languages) {
 		for (const country of ISO.countries) {

--- a/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.ts
+++ b/packages/@romejs/js-compiler/lint/rules/react/jsxA11yLang.ts
@@ -397,30 +397,51 @@ const ISO = {
 	],
 };
 
+// We lazily build this suggestions list as it is massive
+function getSuggestions() {
+	const suggestions = [...ISO.countries];
+
+	for (const language of ISO.languages) {
+		for (const country of ISO.countries) {
+			suggestions.push(`${language}-${country}`);
+		}
+	}
+
+	return suggestions;
+}
+
 const COUNTRY_AND_REGION_REGEX = new RegExp(/([a-z]{2})-([A-Z]{2})/);
 const COUNTRY_REGEX = new RegExp(/([a-z]{2})-([A-Z]{2})/);
 
-function jsxSupportedLang(node: JSXElement): boolean | undefined {
+// Will return the attribute value if invalid
+function jsxSupportedLang(node: JSXElement): undefined | string {
 	const attr = getJSXAttribute(node, "lang");
 
 	if (!attr || !attr.value) {
-		return false;
+		return "undefined";
 	}
-	if (attr.value.type !== "StringLiteral") {
-		return true;
+
+	if (attr.value.type === "StringLiteral") {
+		const {value} = attr.value;
+		if (!langSupported(value)) {
+			return value;
+		}
 	}
-	return langSupported(attr.value.value);
+
+	return undefined;
 }
 
 function langSupported(lang: string): boolean {
 	const countryAndRegionMatches = COUNTRY_AND_REGION_REGEX.exec(lang);
-	const countryMatches = COUNTRY_REGEX.exec(lang);
 	if (countryAndRegionMatches && countryAndRegionMatches.length > 0) {
 		return (
 			ISO.languages.includes(countryAndRegionMatches[1]) &&
 			ISO.countries.includes(countryAndRegionMatches[2])
 		);
-	} else if (countryMatches && countryMatches.length > 0) {
+	}
+
+	const countryMatches = COUNTRY_REGEX.exec(lang);
+	if (countryMatches && countryMatches.length > 0) {
 		return ISO.languages.includes(countryMatches[1]);
 	}
 
@@ -432,10 +453,15 @@ export default {
 		const {node} = path;
 
 		if (isJSXElement(node, "html") && hasJSXAttribute(node, "lang")) {
-			if (jsxSupportedLang(node) === false) {
+			const invalidValue = jsxSupportedLang(node);
+			if (invalidValue !== undefined) {
+				// TODO add an autofix suggestion
 				path.context.addNodeDiagnostic(
 					node,
-					descriptions.LINT.JSX_A11Y_HTML_INVALID_LANG,
+					descriptions.LINT.JSX_A11Y_HTML_INVALID_LANG(
+						invalidValue,
+						getSuggestions(),
+					),
 				);
 			}
 		}


### PR DESCRIPTION
This PR adds suggestions to the `jsxA11yLang` lint rule:

```
  ✖ The lang attribute must have a valid value.

    <html lang="aa-zz"></html>
    ^^^^^^^^^^^^^^^^^^^^^^^^^^

  ℹ Did you mean aa-AF?

  - aa-zz
  + aa-AF

  ℹ Or one of these?

  - aa-AL
  - aa-DZ
  - aa-AS
  - aa-AD
  - aa-AO
  - aa-AI
  - aa-AQ
  - aa-AG
  - aa-AR
  - aa-AM
  and 222 others...
```

The suggestion advice builder can be improved to limit these suggestion since 222 is... excessive.

cc @ematipico