### PR TITLE
Add an ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# formatting change
+4d2c16a16c11bd7d1a5cb1bd5f04115e472a7cf4
+
+# quote migration
+8463545ec585b49c650fcad3900e138b3e1dc9dd
+
+# hard tab migration
+e21450e240cb6165c8f233462a6fce2268ab1a77
+edc8d08272e8d60f175add47d367171857b81a2b


### PR DESCRIPTION
This enables individuals to blame back files ignoring large scale
project changes that impact blames.

Example:
git blame packages/@romejs/core/master/bundler/Bundler.ts  --ignore-revs-file=.git-blame-ignore-revs  | grep bundlebu

BUG=#425

