### PR TITLE
chore: update website for release

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -33,11 +33,10 @@ function Home() {
                 styles.heroBannerTitle,
                 'margin-bottom--lg',
               )}>
-              Rome is an experimental <br />
-              JavaScript toolchain
+              Rome is a JavaScript toolchain
             </h1>
             <h2 className={styles.heroBannerSubtitle}>
-              A compiler, linter, formatter, bundler, testing framework and more
+              Linting, bundling, compiling, testing, and more
             </h2>
           </div>
           <div className={styles.buttons}>
@@ -50,38 +49,9 @@ function Home() {
               Get Started&nbsp;&nbsp;→
             </Link>
           </div>
-          <div className="margin-top--lg">
-            <iframe
-              src="https://ghbtns.com/github-btn.html?user=romejs&amp;repo=rome&amp;type=star&amp;count=true&amp;size=large"
-              frameBorder={0}
-              scrolling={0}
-              width={160}
-              height={30}
-              title="GitHub Stars"
-            />
-          </div>
         </div>
       </header>
       <main>
-        <div
-          className={classnames(
-            'margin-bottom--lg',
-            'padding-vert--lg',
-            styles.calloutPrimary,
-          )}>
-          <div className="container">
-            <div className="row">
-              <div className="col col--8 col--offset-2">
-                <div className="margin-vert--md text--center">
-                  <p className={styles.calloutTagline}>
-                    Rome is experimental and in active development. It is open
-                    for contributors and those interested in experimental tools.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
         <div>
           <div className="container">
             <div className="row">


### PR DESCRIPTION
Updates to the website in preparation for release, ref #496
This PR checks off the following items from [this list](https://github.com/romejs/rome/issues/496#issue-622253571):

- [x] Remove star count from homepage
- [x] Update tagline "Rome is an experimental JavaScript toolchain" to "Rome is a JavaScript toolchain"
- [x] Update tagline "A compiler, linter, formatter, bundler, testing framework and more" to "Linting, bundling, compiling, testing, and more"
- [x] Remove experimental warning banner