### PR TITLE
Add locks when dispatching a worker request

### DIFF
--- a/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
@@ -21,7 +21,6 @@ import {
 	DiagnosticsPrinterFlags,
 	DiagnosticsPrinterOptions,
 } from "./types";
-
 import {
 	formatAnsi,
 	markup,

--- a/packages/@romejs/core/master/Master.ts
+++ b/packages/@romejs/core/master/Master.ts
@@ -66,6 +66,7 @@ import MasterReporter from "./MasterReporter";
 import VirtualModules from "./fs/VirtualModules";
 import {DiagnosticsProcessorOptions} from "@romejs/diagnostics/DiagnosticsProcessor";
 import {toKebabCase} from "@romejs/string-utils";
+import Locker from "../common/utils/Locker";
 
 const STDOUT_MAX_CHUNK_LENGTH = 100_000;
 
@@ -221,6 +222,8 @@ export default class Master {
 			},
 		);
 
+		this.fileLocker = new Locker();
+
 		this.connectedReporters = new MasterReporter(this);
 
 		this.connectedClientsListeningForLogs = new Set();
@@ -279,7 +282,7 @@ export default class Master {
 	cache: Cache;
 	connectedReporters: MasterReporter;
 	logger: Logger;
-
+	fileLocker: Locker<string>;
 	connectedClients: Set<MasterClient>;
 	connectedLSPServers: Set<LSPServer>;
 	connectedClientsListeningForLogs: Set<MasterClient>;

--- a/packages/@romejs/core/master/bundler/BundleRequest.ts
+++ b/packages/@romejs/core/master/bundler/BundleRequest.ts
@@ -182,8 +182,6 @@ export default class BundleRequest {
 			assetPath,
 		};
 
-		const lock = await this.bundler.compileLocker.getLock(source);
-
 		const res: WorkerCompileResult = await this.bundler.request.requestWorkerCompile(
 			path,
 			"compileForBundle",
@@ -192,8 +190,6 @@ export default class BundleRequest {
 			},
 			{},
 		);
-
-		lock.release();
 
 		if (!res.cached) {
 			this.cached = false;

--- a/packages/@romejs/core/master/bundler/Bundler.ts
+++ b/packages/@romejs/core/master/bundler/Bundler.ts
@@ -27,7 +27,6 @@ import {Dict} from "@romejs/typescript-helpers";
 import {readFile} from "@romejs/fs";
 import {flipPathPatterns} from "@romejs/path-match";
 import {markup} from "@romejs/string-markup";
-import Locker from "@romejs/core/common/utils/Locker";
 import {stringifyJSON} from "@romejs/codec-json";
 
 export type BundlerEntryResoluton = {
@@ -43,12 +42,9 @@ export default class Bundler {
 		this.request = req;
 
 		this.entries = [];
-
-		this.compileLocker = new Locker();
 		this.graph = new DependencyGraph(req, config.resolver);
 	}
 
-	compileLocker: Locker<string>;
 	graph: DependencyGraph;
 	master: Master;
 	request: MasterRequest;

--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -568,7 +568,16 @@ export default class MemoryFileSystem {
 		};
 	}
 
-	getMtime(path: AbsoluteFilePath) {
+	maybeGetMtime(path: AbsoluteFilePath): undefined | number {
+		const stats = this.getFileStats(path);
+		if (stats === undefined) {
+			return undefined;
+		} else {
+			return stats.mtime;
+		}
+	}
+
+	getMtime(path: AbsoluteFilePath): number {
 		const stats = this.getFileStats(path);
 		if (stats === undefined) {
 			throw new Error(`File ${path.join()} not in database, cannot get mtime`);


### PR DESCRIPTION
This PR adds the following:

 - Adds locks to all worker file requests. This eliminates race conditions caused by simultaneous requests. This should utilize our caches more effectively.
- Reattempts a worker request if the file changed while it was running.