### PR TITLE
Makes the diagnostic message more specific to the JSX attribute that flags an error.

### DIFF
--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noOnChange.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noOnChange.test.md
@@ -8,13 +8,13 @@
 
 ```
 
- unknown:1 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:8 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ onBlur should be used in favor of onChange. Only use onChange if absolutely necessary without
     negatively affecting keyboard only or screen reader users.
 
     <select onChange={() => {}} />;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^^
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -33,13 +33,13 @@
 
 ```
 
- unknown:1 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:8 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ onBlur should be used in favor of onChange. Only use onChange if absolutely necessary without
     negatively affecting keyboard only or screen reader users.
 
     <select onChange={handleOnChange} />;
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -58,13 +58,13 @@
 
 ```
 
- unknown:1 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:8 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ onBlur should be used in favor of onChange. Only use onChange if absolutely necessary without
     negatively affecting keyboard only or screen reader users.
 
     <option onChange={() => {}} />
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^^
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -83,13 +83,13 @@
 
 ```
 
- unknown:1 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:8 lint/jsx-a11y/noOnChange ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ onBlur should be used in favor of onChange. Only use onChange if absolutely necessary without
     negatively affecting keyboard only or screen reader users.
 
     <option onChange={() => {}} {...props} />
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+            ^^^^^^^^^^^^^^^^^^^
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noOnChange.ts
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noOnChange.ts
@@ -1,5 +1,9 @@
 import {descriptions} from "@romejs/diagnostics";
-import {hasJSXAttribute, isJSXElement} from "@romejs/js-ast-utils";
+import {
+	getJSXAttribute,
+	hasJSXAttribute,
+	isJSXElement,
+} from "@romejs/js-ast-utils";
 import {Path, TransformExitResult} from "@romejs/compiler";
 
 export default {
@@ -19,7 +23,10 @@ export default {
 			return node;
 		}
 
-		context.addNodeDiagnostic(node, descriptions.LINT.JSX_A11Y_NO_ON_CHANGE);
+		context.addNodeDiagnostic(
+			getJSXAttribute(node, "onChange"),
+			descriptions.LINT.JSX_A11Y_NO_ON_CHANGE,
+		);
 
 		return node;
 	},

--- a/packages/@romejs/compiler/lint/rules/react/noStringRefs.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/noStringRefs.test.md
@@ -45,14 +45,14 @@ class Hello extends React.Component {
 
 ```
 
- unknown:4:14 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:19 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using string literals in ref attributes is a deprecated pattern.
 
     2 │      class Hello extends React.Component {
     3 │       render() {
   > 4 │        return <div ref="hello">Hello {this.props.name}</div>;
-      │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │                    ^^^^^^^^^^^
     5 │       }
     6 │      }
 
@@ -79,14 +79,14 @@ class Hello extends React.Component {
 
 ```
 
- unknown:4:14 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:19 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using string literals in ref attributes is a deprecated pattern.
 
     2 │      class Hello extends React.Component {
     3 │       render() {
   > 4 │        return <div ref={`hello`}>Hello {this.props.name}</div>;
-      │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │                    ^^^^^^^^^^^^^
     5 │       }
     6 │      }
 
@@ -113,14 +113,14 @@ class Hello extends React.Component {
 
 ```
 
- unknown:4:14 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:19 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using string literals in ref attributes is a deprecated pattern.
 
     2 │      class Hello extends React.Component {
     3 │       render() {
   > 4 │        return <div ref={'hello'}>Hello {this.props.name}</div>;
-      │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │                    ^^^^^^^^^^^^^
     5 │       }
     6 │      }
 
@@ -147,14 +147,14 @@ class Hello extends React.Component {
 
 ```
 
- unknown:4:16 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:21 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using string literals in ref attributes is a deprecated pattern.
 
     2 │      class Hello extends React.Component {
     3 │        render() {
   > 4 │          return <div ref={`hello${index}`}>Hello {this.props.name}</div>;
-      │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │                      ^^^^^^^^^^^^^^^^^^^^^
     5 │        }
     6 │      }
 
@@ -193,13 +193,13 @@ class Hello extends React.Component {
 
   ℹ See https://reactjs.org/docs/refs-and-the-dom.html#legacy-api-string-refs for more information
 
- unknown:8:14 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:8:19 lint/react/noStringRefs ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using string literals in ref attributes is a deprecated pattern.
 
      7 │       render() {
    > 8 │        return <div ref="hello">Hello {this.props.name}</div>;
-       │               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       │                    ^^^^^^^^^^^
      9 │       }
     10 │      }
 

--- a/packages/@romejs/compiler/lint/rules/react/noStringRefs.ts
+++ b/packages/@romejs/compiler/lint/rules/react/noStringRefs.ts
@@ -54,7 +54,7 @@ export default {
 
 			if (containsStringLiteral(ref) || containsStringContainer(ref)) {
 				context.addNodeDiagnostic(
-					node,
+					ref,
 					descriptions.LINT.REACT_NO_STRING_REFS(
 						"string literals in ref attributes",
 					),


### PR DESCRIPTION
Follow-up to: https://github.com/romejs/rome/pull/501#discussion_r428777239

Sorry for missing this! Updates my previous two contributions so that the added diagnostic messages point to the JSX attributes that cause lint errors. Before, the diagnostic was highlighting the entire JSX Element.
