### PR TITLE
add category to test description in script

### DIFF
--- a/scripts/lint/add.cjs
+++ b/scripts/lint/add.cjs
@@ -64,7 +64,7 @@ write(
 import {testLintMultiple} from "../testHelpers";
 
 test(
-	"${spacedName}",
+	"${category} ${spacedName}",
 	async (t) => {
 		await testLintMultiple(
 			t,


### PR DESCRIPTION
small add of the category to the test description. #520 adds `react` or `jsx-a11y` so this saves having to remember to add that text after you run the add script