### PR TITLE
Rearrange string-markup exports

### DIFF
--- a/packages/@romejs/cli-reporter/Reporter.ts
+++ b/packages/@romejs/cli-reporter/Reporter.ts
@@ -6,7 +6,10 @@
  */
 
 import {
+	MarkupFormatGridOptions,
 	MarkupFormatOptions,
+	MarkupLinesAndWidth,
+	MarkupTagName,
 	ansiEscapes,
 	markupTag,
 	markupToAnsi,
@@ -31,12 +34,7 @@ import stream = require("stream");
 import {CWD_PATH} from "@romejs/path";
 import {Event} from "@romejs/events";
 import readline = require("readline");
-import {
-	MarkupFormatGridOptions,
-	MarkupTagName,
-} from "@romejs/string-markup/types";
 import select from "./select";
-import {MarkupLinesAndWidth} from "@romejs/string-markup/format";
 import {onKeypress} from "./util";
 
 type ListOptions = {

--- a/packages/@romejs/string-markup/format.ts
+++ b/packages/@romejs/string-markup/format.ts
@@ -9,6 +9,7 @@ import {
 	Children,
 	MarkupFormatGridOptions,
 	MarkupFormatNormalizeOptions,
+	MarkupLinesAndWidth,
 	TagNode,
 } from "./types";
 import {parseMarkup} from "./parse";
@@ -145,11 +146,6 @@ export function markupToPlainText(
 		lines: grid.getLines(),
 	};
 }
-
-export type MarkupLinesAndWidth = {
-	width: number;
-	lines: Array<string>;
-};
 
 export function markupToAnsi(
 	input: string,

--- a/packages/@romejs/string-markup/index.ts
+++ b/packages/@romejs/string-markup/index.ts
@@ -13,6 +13,8 @@ export {
 	MarkupFormatGridOptions,
 	MarkupFormatNormalizeOptions,
 	MarkupFormatOptions,
+	MarkupLinesAndWidth,
+	MarkupTagName,
 } from "./types";
 
 export {

--- a/packages/@romejs/string-markup/types.ts
+++ b/packages/@romejs/string-markup/types.ts
@@ -87,3 +87,8 @@ export type MarkupFormatGridOptions = MarkupFormatOptions & {
 export type MarkupFormatNormalizeOptions = MarkupFormatOptions & {
 	stripPositions?: boolean;
 };
+
+export type MarkupLinesAndWidth = {
+	width: number;
+	lines: Array<string>;
+};


### PR DESCRIPTION
Reporter was importing directly from string-markup/types and string-markup/format so I cleaned it up a bit.