### PR TITLE
fix: transpile typescript enums

### DIFF
--- a/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
+++ b/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
@@ -1,0 +1,89 @@
+import {Path} from "@romejs/compiler";
+import {
+	AnyJSExpression,
+	JSObjectProperties,
+	JSObjectProperty,
+	TSEnumMember,
+	jsBindingIdentifier,
+	jsIdentifier,
+	jsNumericLiteral,
+	jsObjectExpression,
+	jsObjectProperty,
+	jsStaticPropertyKey,
+	jsStringLiteral,
+	jsVariableDeclaration,
+	jsVariableDeclarator,
+} from "@romejs/ast";
+
+function getMemberName(member: TSEnumMember): string {
+	return member.id.type === "JSIdentifier" ? member.id.name : member.id.value;
+}
+
+function createMember(
+	key: string | number,
+	value: string | number | AnyJSExpression,
+): JSObjectProperty {
+	const keyNode =
+		typeof key === "string"
+			? jsIdentifier.create({
+					name: key,
+				})
+			: jsNumericLiteral.create({
+					value: key,
+				});
+	let valueNode: AnyJSExpression;
+	if (typeof value === "string") {
+		valueNode = jsStringLiteral.create({value});
+	} else if (typeof value === "number") {
+		valueNode = jsNumericLiteral.create({value});
+	} else {
+		valueNode = value;
+	}
+
+	return jsObjectProperty.create({
+		key: jsStaticPropertyKey.create({
+			value: keyNode,
+		}),
+		value: valueNode,
+	});
+}
+
+export default {
+	name: "enums",
+	enter(path: Path) {
+		const {node} = path;
+
+		if (node.type === "TSEnumDeclaration") {
+			return jsVariableDeclaration.create({
+				kind: "const",
+				declarations: [
+					jsVariableDeclarator.create({
+						id: jsBindingIdentifier.create({
+							name: node.id.name,
+						}),
+						init: jsObjectExpression.create({
+							properties: node.members.reduce<JSObjectProperties>(
+								(properties, member, index) => {
+									if (member.initializer) {
+										properties.push(
+											createMember(getMemberName(member), member.initializer),
+										);
+									} else {
+										properties.push(
+											createMember(index, getMemberName(member)),
+											createMember(getMemberName(member), index),
+										);
+									}
+									return properties;
+								},
+								[],
+							),
+						}),
+					}),
+				],
+			});
+		}
+
+		return node;
+	},
+};

--- a/packages/@romejs/compiler/transforms/index.ts
+++ b/packages/@romejs/compiler/transforms/index.ts
@@ -20,6 +20,7 @@ import nullishCoalescing from "./compile/transpile/nullishCoalescing";
 import callSpread from "./compile/transpile/callSpread";
 import templateLiterals from "./compile/transpile/templateLiterals";
 import objectSpread from "./compile/transpile/objectSpread";
+import enums from "./compile/transpile/enums";
 import optimizeImports from "./compile/validation/optimizeImports";
 import optimizeExports from "./compile/validation/optimizeExports";
 import jsx from "./compile/jsx";
@@ -61,6 +62,7 @@ export const stageTransforms: TransformStageFactories = {
 		classProperties,
 		templateLiterals,
 		callSpread,
+		enums,
 	],
 	compileForBundle: (projectConfig: ProjectConfig, options: CompilerOptions) => {
 		const opts = options.bundle;


### PR DESCRIPTION
This pull request adds a new module to transpile TypeScript enums.

Resolves #534

**Examples:**

1. **Without initializers**
    
    Input:
    ```
    enum Test { a, b }
    ```
    Output:
    ```
    const Test = {a: 0, 0: "a", b: 1, 1: "b"}
    ```

1. **With an explicit numeric initializer**
    
    Input:
    ```
    enum Test { a = 3, b }
    ```
    Output:
    ```
    const Test = {a: 3, 3: "a", b: 4, 4: "b"}
    ```

1. **With heterogenous initializers**
    
    Input:
    ```
    enum Test { a = 'foo', b = 0, c }
    ```
    Output:
    ```
    const Test = {a: "foo", b: 0, 0: "b", c: 1, 1: "c"}
    ```
