### PR TITLE
fix: transpile typescript enums

### DIFF
--- a/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
+++ b/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
@@ -2,12 +2,11 @@ import {
 	AnyJSExpression,
 	AnyJSStatement,
 	JSBindingIdentifier,
-	JSCallExpression,
 	JSFunctionExpression,
 	TSEnumDeclaration,
+	jsCallExpression,
 	jsNumericLiteral,
 	jsStringLiteral,
-	jsCallExpression,
 } from "@romejs/ast";
 import {LetBinding, Path, VarBinding} from "@romejs/compiler";
 import {REDUCE_REMOVE} from "@romejs/compiler/constants";
@@ -22,9 +21,11 @@ function buildEnumWrapper(
 	id: JSBindingIdentifier,
 	assignments: Array<AnyJSExpression>,
 ): AnyJSExpression {
-	const expressionStatement = jsCallExpression.assert(template.expression`
+	const expressionStatement = jsCallExpression.assert(
+		template.expression`
 		(function (${id}) {})(${id} || (${id} = {}));
-	`);
+	`,
+	);
 	const functionExpression = (expressionStatement.callee as JSFunctionExpression);
 	functionExpression.body.body = (assignments as Array<AnyJSStatement>);
 	return (expressionStatement as AnyJSExpression);

--- a/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
+++ b/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
@@ -22,9 +22,9 @@ function buildEnumWrapper(
 	id: JSBindingIdentifier,
 	assignments: Array<AnyJSExpression>,
 ): AnyJSExpression {
-	const expressionStatement = (template.expression`
+	const expressionStatement = jsCallExpression.assert(template.expression`
 		(function (${id}) {})(${id} || (${id} = {}));
-	` as JSCallExpression);
+	`);
 	const functionExpression = (expressionStatement.callee as JSFunctionExpression);
 	functionExpression.body.body = (assignments as Array<AnyJSStatement>);
 	return (expressionStatement as AnyJSExpression);

--- a/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
+++ b/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
@@ -1,0 +1,248 @@
+import {
+	AnyJSExpression,
+	AnyJSStatement,
+	JSBinaryExpression,
+	JSBindingIdentifier,
+	JSCallExpression,
+	JSFunctionExpression,
+	JSUnaryExpression,
+	TSEnumDeclaration,
+	jsNumericLiteral,
+	jsStringLiteral,
+} from "@romejs/ast";
+import {LetBinding, Path, VarBinding} from "@romejs/compiler";
+import {REDUCE_REMOVE} from "@romejs/compiler/constants";
+import {template} from "@romejs/js-ast-utils";
+
+interface PreviousEnumMembers {
+	[name: string]: number | string;
+}
+
+function buildEnumWrapper(
+	id: JSBindingIdentifier,
+	assignments: Array<AnyJSExpression>,
+): AnyJSExpression {
+	const expressionStatement = (template.expression`
+		(function (${id}) {})(${id} || (${id} = {}));
+	` as JSCallExpression);
+	const functionExpression = (expressionStatement.callee as JSFunctionExpression);
+	functionExpression.body.body = (assignments as Array<AnyJSStatement>);
+	return (expressionStatement as AnyJSExpression);
+}
+
+function buildEnumMember(
+	isString: boolean,
+	id: JSBindingIdentifier,
+	name: string,
+	value: AnyJSExpression,
+): AnyJSExpression {
+	return (isString ? buildStringAssignment : buildNumericAssignment)(
+		id,
+		name,
+		value,
+	);
+}
+
+function buildNumericAssignment(
+	id: JSBindingIdentifier,
+	name: string,
+	value: AnyJSExpression,
+): AnyJSExpression {
+	const nameNode = jsStringLiteral.create({value: name});
+	return template.expression`
+		${id}[${id}[${nameNode}] = ${value}] = ${nameNode};
+	`;
+}
+
+function buildStringAssignment(
+	id: JSBindingIdentifier,
+	name: string,
+	value: AnyJSExpression,
+): AnyJSExpression {
+	const nameNode = jsStringLiteral.create({value: name});
+	return template.expression`
+		${id}[${nameNode}] = ${value};
+	`;
+}
+
+function enumFill(node: TSEnumDeclaration): AnyJSExpression {
+	const x = translateEnumValues(node);
+	const assignments = x.map(([memberName, memberValue]) =>
+		buildEnumMember(
+			typeof memberValue !== "string" && memberValue.type === "JSStringLiteral",
+			({...node.id} as JSBindingIdentifier),
+			memberName,
+			memberValue,
+		)
+	);
+	return buildEnumWrapper(({...node.id} as JSBindingIdentifier), assignments);
+}
+
+function translateEnumValues(
+	node: TSEnumDeclaration,
+): Array<[string, AnyJSExpression]> {
+	const seen: PreviousEnumMembers = Object.create(null);
+	let prev: number | undefined = -1;
+	return node.members.map((member) => {
+		let value: AnyJSExpression;
+		const initializer = member.initializer;
+		const name =
+			member.id.type === "JSIdentifier" ? member.id.name : member.id.value;
+
+		if (initializer) {
+			const constValue = evaluate(initializer, seen);
+			if (constValue !== undefined) {
+				seen[name] = constValue;
+				if (typeof constValue === "number") {
+					value = jsNumericLiteral.create({value: constValue});
+					prev = constValue;
+				} else {
+					value = jsStringLiteral.create({value: constValue});
+					prev = undefined;
+				}
+			} else {
+				value = initializer;
+				prev = undefined;
+			}
+		} else {
+			if (prev !== undefined) {
+				prev++;
+				value = jsNumericLiteral.create({value: prev});
+				seen[name] = prev;
+			} else {
+				throw new Error("Enum member must have initializer");
+			}
+		}
+
+		return [name, value];
+	});
+}
+
+function evaluate(
+	expr: AnyJSExpression,
+	seen: PreviousEnumMembers,
+): number | string | undefined {
+	return evalConstant(expr);
+
+	function evalConstant(expr: AnyJSExpression): number | string | undefined {
+		switch (expr.type) {
+			case "JSStringLiteral":
+				return expr.value;
+			case "JSUnaryExpression":
+				return evalUnaryExpression(expr);
+			case "JSBinaryExpression":
+				return evalBinaryExpression(expr);
+			case "JSNumericLiteral":
+				return expr.value;
+			case "JSReferenceIdentifier":
+				return seen[expr.name];
+			case "JSTemplateLiteral": {
+				if (expr.quasis.length === 1) {
+					return expr.quasis[0].cooked;
+				}
+				return undefined;
+			}
+			default:
+				return undefined;
+		}
+	}
+
+	function evalUnaryExpression(
+		expr: JSUnaryExpression,
+	): number | string | undefined {
+		const value = evalConstant(expr.argument);
+		if (value === undefined) {
+			return;
+		}
+
+		switch (expr.operator) {
+			case "+":
+				return value;
+			case "-":
+				return -value;
+			case "~":
+				return ~value;
+			default:
+				return undefined;
+		}
+	}
+
+	function evalBinaryExpression(expr: JSBinaryExpression): number | undefined {
+		const left = Number(evalConstant(expr.left));
+		if (left === undefined) {
+			return;
+		}
+		const right = Number(evalConstant(expr.right));
+		if (right === undefined) {
+			return;
+		}
+
+		switch (expr.operator) {
+			case "|":
+				return left | right;
+			case "&":
+				return left & right;
+			case ">>":
+				return left >> right;
+			case ">>>":
+				return left >>> right;
+			case "<<":
+				return left << right;
+			case "^":
+				return left ^ right;
+			case "*":
+				return left * right;
+			case "/":
+				return left / right;
+			case "+":
+				return left + right;
+			case "-":
+				return left - right;
+			case "%":
+				return left % right;
+			default:
+				return undefined;
+		}
+	}
+}
+
+export default {
+	name: "enums",
+	enter(path: Path) {
+		const {node} = path;
+
+		if (node.type !== "TSEnumDeclaration") {
+			return node;
+		}
+
+		if (node.const) {
+			throw new Error('"const" enums are not supported');
+		}
+
+		if (node.declare) {
+			return REDUCE_REMOVE;
+		}
+
+		const fill = enumFill(node);
+
+		switch (path.parent.type) {
+			case "JSBlockStatement":
+			case "JSExportLocalDeclaration":
+			case "JSRoot": {
+				const BindingCtor =
+					path.parent.type === "JSRoot" ? VarBinding : LetBinding;
+				path.scope.addBinding(
+					new BindingCtor({
+						node: node.id,
+						name: node.id.name,
+						scope: path.scope,
+					}),
+				);
+				return fill;
+			}
+
+			default:
+				throw new Error(`Unexpected enum parent '${path.parent.type}`);
+		}
+	},
+};

--- a/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
+++ b/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
@@ -7,6 +7,7 @@ import {
 	TSEnumDeclaration,
 	jsNumericLiteral,
 	jsStringLiteral,
+	jsCallExpression,
 } from "@romejs/ast";
 import {LetBinding, Path, VarBinding} from "@romejs/compiler";
 import {REDUCE_REMOVE} from "@romejs/compiler/constants";

--- a/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
+++ b/packages/@romejs/compiler/transforms/compile/transpile/enums.ts
@@ -1,18 +1,17 @@
 import {
 	AnyJSExpression,
 	AnyJSStatement,
-	JSBinaryExpression,
 	JSBindingIdentifier,
 	JSCallExpression,
 	JSFunctionExpression,
-	JSUnaryExpression,
 	TSEnumDeclaration,
 	jsNumericLiteral,
 	jsStringLiteral,
 } from "@romejs/ast";
 import {LetBinding, Path, VarBinding} from "@romejs/compiler";
 import {REDUCE_REMOVE} from "@romejs/compiler/constants";
-import {template} from "@romejs/js-ast-utils";
+import {descriptions} from "@romejs/diagnostics";
+import {template, tryStaticEvaluation} from "@romejs/js-ast-utils";
 
 interface PreviousEnumMembers {
 	[name: string]: number | string;
@@ -36,11 +35,9 @@ function buildEnumMember(
 	name: string,
 	value: AnyJSExpression,
 ): AnyJSExpression {
-	return (isString ? buildStringAssignment : buildNumericAssignment)(
-		id,
-		name,
-		value,
-	);
+	return isString
+		? buildStringAssignment(id, name, value)
+		: buildNumericAssignment(id, name, value);
 }
 
 function buildNumericAssignment(
@@ -90,7 +87,10 @@ function translateEnumValues(
 			member.id.type === "JSIdentifier" ? member.id.name : member.id.value;
 
 		if (initializer) {
-			const constValue = evaluate(initializer, seen);
+			let {value: constValue, bailed} = tryStaticEvaluation(initializer);
+			if (bailed && initializer.type === "JSReferenceIdentifier") {
+				constValue = seen[initializer.name];
+			}
 			if (constValue !== undefined) {
 				seen[name] = constValue;
 				if (typeof constValue === "number") {
@@ -118,105 +118,21 @@ function translateEnumValues(
 	});
 }
 
-function evaluate(
-	expr: AnyJSExpression,
-	seen: PreviousEnumMembers,
-): number | string | undefined {
-	return evalConstant(expr);
-
-	function evalConstant(expr: AnyJSExpression): number | string | undefined {
-		switch (expr.type) {
-			case "JSStringLiteral":
-				return expr.value;
-			case "JSUnaryExpression":
-				return evalUnaryExpression(expr);
-			case "JSBinaryExpression":
-				return evalBinaryExpression(expr);
-			case "JSNumericLiteral":
-				return expr.value;
-			case "JSReferenceIdentifier":
-				return seen[expr.name];
-			case "JSTemplateLiteral": {
-				if (expr.quasis.length === 1) {
-					return expr.quasis[0].cooked;
-				}
-				return undefined;
-			}
-			default:
-				return undefined;
-		}
-	}
-
-	function evalUnaryExpression(
-		expr: JSUnaryExpression,
-	): number | string | undefined {
-		const value = evalConstant(expr.argument);
-		if (value === undefined) {
-			return;
-		}
-
-		switch (expr.operator) {
-			case "+":
-				return value;
-			case "-":
-				return -value;
-			case "~":
-				return ~value;
-			default:
-				return undefined;
-		}
-	}
-
-	function evalBinaryExpression(expr: JSBinaryExpression): number | undefined {
-		const left = Number(evalConstant(expr.left));
-		if (left === undefined) {
-			return;
-		}
-		const right = Number(evalConstant(expr.right));
-		if (right === undefined) {
-			return;
-		}
-
-		switch (expr.operator) {
-			case "|":
-				return left | right;
-			case "&":
-				return left & right;
-			case ">>":
-				return left >> right;
-			case ">>>":
-				return left >>> right;
-			case "<<":
-				return left << right;
-			case "^":
-				return left ^ right;
-			case "*":
-				return left * right;
-			case "/":
-				return left / right;
-			case "+":
-				return left + right;
-			case "-":
-				return left - right;
-			case "%":
-				return left % right;
-			default:
-				return undefined;
-		}
-	}
-}
-
 export default {
 	name: "enums",
 	enter(path: Path) {
-		const {node} = path;
+		const {context, node} = path;
 
 		if (node.type !== "TSEnumDeclaration") {
 			return node;
 		}
 
 		if (node.const) {
-			throw new Error('"const" enums are not supported');
+			context.addNodeDiagnostic(
+				node,
+				descriptions.COMPILER.CONST_ENUMS_UNSUPPORTED,
+			);
+			return REDUCE_REMOVE;
 		}
 
 		if (node.declare) {

--- a/packages/@romejs/compiler/transforms/index.ts
+++ b/packages/@romejs/compiler/transforms/index.ts
@@ -20,6 +20,7 @@ import nullishCoalescing from "./compile/transpile/nullishCoalescing";
 import callSpread from "./compile/transpile/callSpread";
 import templateLiterals from "./compile/transpile/templateLiterals";
 import objectSpread from "./compile/transpile/objectSpread";
+import enums from "./compile/transpile/enums";
 import optimizeImports from "./compile/validation/optimizeImports";
 import optimizeExports from "./compile/validation/optimizeExports";
 import jsx from "./compile/jsx";
@@ -61,6 +62,7 @@ export const stageTransforms: TransformStageFactories = {
 		classProperties,
 		templateLiterals,
 		callSpread,
+		enums,
 	],
 	compileForBundle: (projectConfig: ProjectConfig, options: CompilerOptions) => {
 		const opts = options.bundle;

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -16,6 +16,7 @@ export type DiagnosticCategory =
 	| "bundler/moduleCycle"
 	| "bundler/topLevelAwait"
 	| "compile/classes"
+	| "compile/const-enums"
 	| "compile/jsx"
 	| "flags/invalid"
 	| "format/disabled"

--- a/packages/@romejs/diagnostics/descriptions/compiler.ts
+++ b/packages/@romejs/diagnostics/descriptions/compiler.ts
@@ -10,4 +10,8 @@ export const compiler = createDiagnosticsCategory({
 		category: "compile/jsx",
 		message: "JSX is not XML",
 	},
+	CONST_ENUMS_UNSUPPORTED: {
+		category: "compile/const-enums",
+		message: "Const enums are not supported",
+	},
 });

--- a/packages/@romejs/js-ast-utils/index.ts
+++ b/packages/@romejs/js-ast-utils/index.ts
@@ -41,3 +41,4 @@ export {default as createMemberProperty} from "./createMemberProperty";
 export {default as hasJSXAttribute} from "./hasJSXAttribute";
 export {default as getJSXAttribute} from "./getJSXAttribute";
 export {default as isJSXElement} from "./isJSXElement";
+export {default as tryStaticEvaluation} from "./tryStaticEvaluation";

--- a/packages/@romejs/js-ast-utils/tryStaticEvaluation.ts
+++ b/packages/@romejs/js-ast-utils/tryStaticEvaluation.ts
@@ -1,0 +1,97 @@
+import {
+	AnyJSExpression,
+	JSBinaryExpression,
+	JSUnaryExpression,
+} from "@romejs/ast";
+
+function evalConstant(expr: AnyJSExpression) {
+	switch (expr.type) {
+		case "JSStringLiteral":
+			return expr.value;
+		case "JSUnaryExpression":
+			return evalUnaryExpression(expr);
+		case "JSBinaryExpression":
+			return evalBinaryExpression(expr);
+		case "JSNumericLiteral":
+			return expr.value;
+		case "JSTemplateLiteral": {
+			if (expr.quasis.length === 1) {
+				return expr.quasis[0].cooked;
+			}
+			return undefined;
+		}
+		default:
+			return undefined;
+	}
+}
+
+function evalUnaryExpression(
+	expr: JSUnaryExpression,
+): number | string | undefined {
+	const value = evalConstant(expr.argument);
+	if (value === undefined) {
+		return;
+	}
+
+	switch (expr.operator) {
+		case "+":
+			return value;
+		case "-":
+			return -value;
+		case "~":
+			return ~value;
+		default:
+			return undefined;
+	}
+}
+
+function evalBinaryExpression(expr: JSBinaryExpression): number | undefined {
+	const left = Number(evalConstant(expr.left));
+	if (left === undefined) {
+		return;
+	}
+	const right = Number(evalConstant(expr.right));
+	if (right === undefined) {
+		return;
+	}
+
+	switch (expr.operator) {
+		case "|":
+			return left | right;
+		case "&":
+			return left & right;
+		case ">>":
+			return left >> right;
+		case ">>>":
+			return left >>> right;
+		case "<<":
+			return left << right;
+		case "^":
+			return left ^ right;
+		case "*":
+			return left * right;
+		case "/":
+			return left / right;
+		case "+":
+			return left + right;
+		case "-":
+			return left - right;
+		case "%":
+			return left % right;
+		default:
+			return undefined;
+	}
+}
+
+export default function tryStaticEvaluation(
+	expr: AnyJSExpression,
+): {
+	value?: string | number;
+	bailed?: boolean;
+} {
+	const value = evalConstant(expr);
+	return {
+		value,
+		bailed: !value,
+	};
+}


### PR DESCRIPTION
This pull request adds a new module to transpile TypeScript enums. Functionality matches the TypeScript compiler and the related Babel transform.

Resolves #534
Supersedes #536

**Examples:**

Input:
```ts
enum Test1 {a, b}

enum Test2 {a = 3, b = 10}

enum Test3 {a = "foo", b = "bar"}

enum Test4 {a = 7, b = "bar"}

enum Test5 {a = 5 + 5, b}

enum Test6 {a = 5 + 5, b = a}
````

Output:
```ts
function(Test1) {
	Test1[Test1["a"] = 0] = "a"
	Test1[Test1["b"] = 1] = "b"
}(Test1 || (Test1 = {}))

function(Test2) {
	Test2[Test2["a"] = 3] = "a"
	Test2[Test2["b"] = 10] = "b"
}(Test2 || (Test2 = {}))

function(Test3) {
	Test3["a"] = "foo"
	Test3["b"] = "bar"
}(Test3 || (Test3 = {}))

function(Test4) {
	Test4[Test4["a"] = 7] = "a"
	Test4["b"] = "bar"
}(Test4 || (Test4 = {}))

function(Test5) {
	Test5[Test5["a"] = 10] = "a"
	Test5[Test5["b"] = 11] = "b"
}(Test5 || (Test5 = {}))

function(Test6) {
	Test5[Test6["a"] = 10] = "a"
	Test5[Test6["b"] = 10] = "b"
}(Test6 || (Test6 = {}))
```