### PR TITLE
feat: check conditional expression in noCondAssign

### DIFF
--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.md
@@ -127,16 +127,26 @@ do {
 ### `4`
 
 ```
-✔ No known problems!
+
+ unknown:1:1 lint/js/noCondAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Do not assign variables in loop conditions.
+
+    (foo = bar) ? foo() : baz();
+     ^^^^^^^^^
+
+  ℹ It is a common typo to mistype an equality operator as an assignment operator.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
 
 ```
 
 ### `4: formatted`
 
 ```
-while ((foo = foo.bar) !== undefined) {
-	console.log(foo);
-}
+(foo = bar) ? foo() : baz();
 
 ```
 
@@ -150,8 +160,38 @@ while ((foo = foo.bar) !== undefined) {
 ### `5: formatted`
 
 ```
+while ((foo = foo.bar) !== undefined) {
+	console.log(foo);
+}
+
+```
+
+### `6`
+
+```
+✔ No known problems!
+
+```
+
+### `6: formatted`
+
+```
 if (foo++ === 3) {
 	console.log(foo);
 }
+
+```
+
+### `7`
+
+```
+✔ No known problems!
+
+```
+
+### `7: formatted`
+
+```
+foo = bar ? foo() : baz();
 
 ```

--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.ts
@@ -35,6 +35,9 @@ test(
 						do {
 							console.log('foo');
 						} while (foo = 'bar')
+                    `,
+                    dedent`
+                        (foo = bar) ? foo() : baz();
 					`,
 				],
 				valid: [
@@ -47,7 +50,10 @@ test(
 						if (foo++ === 3) {
 							console.log(foo);
 						}
-					`,
+                    `,
+                    dedent`
+                        foo = bar ? foo() : baz();
+                    `,
 				],
 			},
 			{category: "lint/js/noCondAssign"},

--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.ts
@@ -18,8 +18,8 @@ export default {
 			(node.type === "JSIfStatement" ||
 			node.type === "JSForStatement" ||
 			node.type === "JSWhileStatement" ||
-            node.type === "JSDoWhileStatement" ||
-            node.type === "JSConditionalExpression") &&
+			node.type === "JSDoWhileStatement" ||
+			node.type === "JSConditionalExpression") &&
 			node.test &&
 			node.test.type === "JSAssignmentExpression"
 		) {

--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.ts
@@ -18,7 +18,8 @@ export default {
 			(node.type === "JSIfStatement" ||
 			node.type === "JSForStatement" ||
 			node.type === "JSWhileStatement" ||
-			node.type === "JSDoWhileStatement") &&
+            node.type === "JSDoWhileStatement" ||
+            node.type === "JSConditionalExpression") &&
 			node.test &&
 			node.test.type === "JSAssignmentExpression"
 		) {

--- a/packages/@romejs/compiler/lint/rules/react/noAccessStateInSetState.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/noAccessStateInSetState.test.md
@@ -26,7 +26,7 @@
 
 ```
 
-### `0: formatted but unfixable`
+### `0: formatted`
 
 ```
 function increment() {
@@ -57,7 +57,7 @@ function increment() {
 
 ```
 
-### `1: formatted but unfixable`
+### `1: formatted`
 
 ```
 function increment() {
@@ -89,7 +89,7 @@ function increment() {
 
 ```
 
-### `2: formatted but unfixable`
+### `2: formatted`
 
 ```
 this.setState({
@@ -121,7 +121,7 @@ this.setState({
 
 ```
 
-### `3: formatted but unfixable`
+### `3: formatted`
 
 ```
 this.setState({
@@ -153,7 +153,7 @@ this.setState({
 
 ```
 
-### `4: formatted but unfixable`
+### `4: formatted`
 
 ```
 this.setState({
@@ -185,7 +185,7 @@ this.setState({
 
 ```
 
-### `5: formatted but unfixable`
+### `5: formatted`
 
 ```
 this.setState({
@@ -218,7 +218,7 @@ this.setState({
 
 ```
 
-### `6: formatted but unfixable`
+### `6: formatted`
 
 ```
 this.setState({
@@ -252,7 +252,7 @@ this.setState({
 
 ```
 
-### `7: formatted but unfixable`
+### `7: formatted`
 
 ```
 this.setState({
@@ -285,7 +285,7 @@ this.setState({
 
 ```
 
-### `8: formatted but unfixable`
+### `8: formatted`
 
 ```
 this.setState({
@@ -318,7 +318,7 @@ this.setState({
 
 ```
 
-### `9: formatted but unfixable`
+### `9: formatted`
 
 ```
 this.setState({


### PR DESCRIPTION
I think the `test` node in `ternary` should be checked :)

* invalid
```
(foo = bar) ? foo() : baz();
```