### PR TITLE
feat add conditional expression in noCondAssign

### DIFF
--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.md
@@ -127,16 +127,26 @@ do {
 ### `4`
 
 ```
-✔ No known problems!
+
+ unknown:1:1 lint/js/noCondAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Do not assign variables in loop conditions.
+
+    (foo = bar) ? foo() : bar();
+     ^^^^^^^^^
+
+  ℹ It is a common typo to mistype an equality operator as an assignment operator.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
 
 ```
 
 ### `4: formatted`
 
 ```
-while ((foo = foo.bar) !== undefined) {
-	console.log(foo);
-}
+(foo = bar) ? foo() : bar();
 
 ```
 
@@ -150,8 +160,38 @@ while ((foo = foo.bar) !== undefined) {
 ### `5: formatted`
 
 ```
+while ((foo = foo.bar) !== undefined) {
+	console.log(foo);
+}
+
+```
+
+### `6`
+
+```
+✔ No known problems!
+
+```
+
+### `6: formatted`
+
+```
 if (foo++ === 3) {
 	console.log(foo);
 }
+
+```
+
+### `7`
+
+```
+✔ No known problems!
+
+```
+
+### `7: formatted`
+
+```
+foo = bar ? foo() : bar();
 
 ```

--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.ts
@@ -50,10 +50,10 @@ test(
 						if (foo++ === 3) {
 							console.log(foo);
 						}
-                    `,
+					`,
 					dedent`
-                        foo = bar ? foo() : bar();
-                    `,
+						foo = bar ? foo() : bar();
+					`,
 				],
 			},
 			{category: "lint/js/noCondAssign"},

--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.test.ts
@@ -35,6 +35,9 @@ test(
 						do {
 							console.log('foo');
 						} while (foo = 'bar')
+                    `,
+					dedent`
+						(foo = bar) ? foo() : bar();
 					`,
 				],
 				valid: [
@@ -47,7 +50,10 @@ test(
 						if (foo++ === 3) {
 							console.log(foo);
 						}
-					`,
+                    `,
+					dedent`
+                        foo = bar ? foo() : bar();
+                    `,
 				],
 			},
 			{category: "lint/js/noCondAssign"},

--- a/packages/@romejs/compiler/lint/rules/js/noCondAssign.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noCondAssign.ts
@@ -18,7 +18,8 @@ export default {
 			(node.type === "JSIfStatement" ||
 			node.type === "JSForStatement" ||
 			node.type === "JSWhileStatement" ||
-			node.type === "JSDoWhileStatement") &&
+			node.type === "JSDoWhileStatement" ||
+			node.type === "JSConditionalExpression") &&
 			node.test &&
 			node.test.type === "JSAssignmentExpression"
 		) {


### PR DESCRIPTION
I think the `test` node in `ternary` should be checked :)

* invalid
```
(foo = bar) ? foo() : baz();
``` 
CI failed cause #548.