### PR TITLE
Refactor tryStaticEvaluation

### DIFF
--- a/packages/@romejs/js-ast-utils/index.ts
+++ b/packages/@romejs/js-ast-utils/index.ts
@@ -42,3 +42,4 @@ export {default as hasJSXAttribute} from "./hasJSXAttribute";
 export {default as getJSXAttribute} from "./getJSXAttribute";
 export {default as isJSXElement} from "./isJSXElement";
 export {default as tryStaticEvaluation} from "./tryStaticEvaluation";
+export {default as tryStaticEvaluationPath} from "./tryStaticEvaluationPath";

--- a/packages/@romejs/js-ast-utils/tryStaticEvaluation.ts
+++ b/packages/@romejs/js-ast-utils/tryStaticEvaluation.ts
@@ -1,97 +1,205 @@
 import {
-	AnyJSExpression,
+	AnyNode,
 	JSBinaryExpression,
+	JSTemplateLiteral,
 	JSUnaryExpression,
 } from "@romejs/ast";
+import {ConstBinding, Scope} from "@romejs/compiler";
 
-function evalConstant(expr: AnyJSExpression) {
-	switch (expr.type) {
-		case "JSStringLiteral":
-			return expr.value;
-		case "JSUnaryExpression":
-			return evalUnaryExpression(expr);
-		case "JSBinaryExpression":
-			return evalBinaryExpression(expr);
-		case "JSNumericLiteral":
-			return expr.value;
-		case "JSTemplateLiteral": {
-			if (expr.quasis.length === 1) {
-				return expr.quasis[0].cooked;
-			}
-			return undefined;
-		}
-		default:
-			return undefined;
-	}
+export type EvalResult = {
+	value: undefined | null | string | number | boolean;
+	bailed: boolean;
+};
+
+export type EvalOptions = {};
+
+const BAILED: EvalResult = {
+	bailed: true,
+	value: undefined,
+};
+
+function createResult(value: EvalResult["value"]): EvalResult {
+	return {
+		bailed: false,
+		value,
+	};
 }
 
 function evalUnaryExpression(
 	expr: JSUnaryExpression,
-): number | string | undefined {
-	const value = evalConstant(expr.argument);
-	if (value === undefined) {
-		return;
+	scope: Scope,
+	opts: EvalOptions,
+): EvalResult {
+	const res = tryStaticEvaluation(expr.argument, scope, opts);
+
+	if (!res.bailed) {
+		// We do not care about TS protections
+		// rome-ignore lint/js/noExplicitAny
+		const value = (res.value as any);
+
+		switch (expr.operator) {
+			case "+":
+				return createResult(+value);
+
+			case "-":
+				return createResult(-value);
+
+			case "~":
+				return createResult(~value);
+		}
 	}
 
-	switch (expr.operator) {
-		case "+":
-			return value;
-		case "-":
-			return -value;
-		case "~":
-			return ~value;
-		default:
-			return undefined;
-	}
+	return BAILED;
 }
 
-function evalBinaryExpression(expr: JSBinaryExpression): number | undefined {
-	const left = Number(evalConstant(expr.left));
-	if (left === undefined) {
-		return;
+function evalBinaryExpression(
+	expr: JSBinaryExpression,
+	scope: Scope,
+	opts: EvalOptions,
+): EvalResult {
+	const left = tryStaticEvaluation(expr.left, scope, opts);
+	if (left.bailed) {
+		return BAILED;
 	}
-	const right = Number(evalConstant(expr.right));
-	if (right === undefined) {
-		return;
+
+	const right = tryStaticEvaluation(expr.right, scope, opts);
+	if (right.bailed) {
+		return BAILED;
 	}
+
+	// We do not care about TS protections
+	// rome-ignore lint/js/noExplicitAny
+	const l = (left.value as any);
+	// rome-ignore lint/js/noExplicitAny
+	const r = (right.value as any);
 
 	switch (expr.operator) {
 		case "|":
-			return left | right;
+			return createResult(l | r);
+
 		case "&":
-			return left & right;
+			return createResult(l & r);
+
 		case ">>":
-			return left >> right;
+			return createResult(l >> r);
+
 		case ">>>":
-			return left >>> right;
+			return createResult(l >>> r);
+
 		case "<<":
-			return left << right;
+			return createResult(l << r);
+
 		case "^":
-			return left ^ right;
+			return createResult(l ^ r);
+
 		case "*":
-			return left * right;
+			return createResult(l * r);
+
 		case "/":
-			return left / right;
+			return createResult(l / r);
+
 		case "+":
-			return left + right;
+			return createResult(l + r);
+
 		case "-":
-			return left - right;
+			return createResult(l - r);
+
 		case "%":
-			return left % right;
+			return createResult(l % r);
+
 		default:
-			return undefined;
+			return BAILED;
 	}
 }
 
+function evalTemplateLiteral(
+	expr: JSTemplateLiteral,
+	scope: Scope,
+	opts: EvalOptions,
+): EvalResult {
+	const {expressions, quasis} = expr;
+
+	let str = "";
+	let bailed = false;
+	let index = 0;
+
+	for (const elem of quasis) {
+		str += elem.cooked;
+
+		if (index < expressions.length) {
+			const res = tryStaticEvaluation(expressions[index++], scope, opts);
+
+			if (res.bailed) {
+				bailed = true;
+				break;
+			}
+
+			str += res.value;
+		}
+	}
+
+	if (bailed) {
+		return BAILED;
+	} else {
+		return createResult(str);
+	}
+}
+
+const cache: WeakMap<AnyNode, EvalResult> = new WeakMap();
+
 export default function tryStaticEvaluation(
-	expr: AnyJSExpression,
-): {
-	value?: string | number;
-	bailed?: boolean;
-} {
-	const value = evalConstant(expr);
-	return {
-		value,
-		bailed: !value,
-	};
+	node: AnyNode,
+	scope: Scope,
+	opts: EvalOptions = {},
+): EvalResult {
+	const cached = cache.get(node);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let res: EvalResult = BAILED;
+
+	switch (node.type) {
+		case "JSUnaryExpression": {
+			res = evalUnaryExpression(node, scope, opts);
+			break;
+		}
+
+		case "JSBinaryExpression": {
+			res = evalBinaryExpression(node, scope, opts);
+			break;
+		}
+
+		case "JSNullLiteral": {
+			res = createResult(null);
+			break;
+		}
+
+		case "JSStringLiteral":
+		case "JSBooleanLiteral":
+		case "JSNumericLiteral": {
+			res = createResult(node.value);
+			break;
+		}
+
+		case "JSReferenceIdentifier": {
+			const binding = scope.getBinding(node.name);
+			if (binding === undefined && node.name === "undefined") {
+				res = createResult(undefined);
+			} else {
+				if (binding instanceof ConstBinding && binding.value !== undefined) {
+					res = tryStaticEvaluation(binding.value, binding.scope, opts);
+				}
+			}
+			break;
+		}
+
+		case "JSTemplateLiteral": {
+			res = evalTemplateLiteral(node, scope, opts);
+			break;
+		}
+	}
+
+	cache.set(node, res);
+	return res;
 }

--- a/packages/@romejs/js-ast-utils/tryStaticEvaluationPath.ts
+++ b/packages/@romejs/js-ast-utils/tryStaticEvaluationPath.ts
@@ -1,0 +1,12 @@
+import {Path} from "@romejs/compiler";
+import tryStaticEvaluation, {
+	EvalOptions,
+	EvalResult,
+} from "./tryStaticEvaluation";
+
+export default function tryStaticEvaluationPath(
+	path: Path,
+	opts?: EvalOptions,
+): EvalResult {
+	return tryStaticEvaluation(path.node, path.scope, opts);
+}


### PR DESCRIPTION
This PR makes the following changes to `tryStaticEvaluatiuon`:

 - Add `const` resolution to `tryStaticEvaluation` allow variable references to be resolved
 - Add full support for `JSTemplateLiteral`
 - Allows `undefined` to be returned
 - Adds caching

This makes it a lot more versatile and should allow for better linting capabilities.

`tryStaticEvaluationPath` is available to just pass a `Path` instance into it for easier usage.

If we have a prefer const lint rule and autofix then this it would be a lot more powerful. There's not really a way for us to compute if a binding is only assigned once as a pseudo-constant without recursing deep which would kill our scope performance.