### PR TITLE
Update rules/js tests to use new testLint

### DIFF
--- a/packages/@romejs/compiler/lint/rules/js/noDuplicateGroupNamesInRegularExpressions.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noDuplicateGroupNamesInRegularExpressions.test.ts
@@ -13,7 +13,11 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			`/(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>[0-9])/`,
+			{
+				invalid: [
+					"/(?<month>[0-9])-(?<year>[0-9])-(?<month>[0-9])-(?<year>[0-9])-(?<day>[0-9])-([0-9])-(?<month>[0-9])/",
+				],
+			},
 			{category: "lint/js/noDuplicateGroupNamesInRegularExpressions"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noDuplicateKeys.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noDuplicateKeys.test.md
@@ -8,15 +8,15 @@
 
 ```
 
- unknown:2:2 lint/js/noDuplicateKeys ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2:1 lint/js/noDuplicateKeys ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid duplicate component key. Check the test key.
 
     1 │ const foo = {
-  > 2 │   test: true,
-      │   ^^^^
-    3 │   test2: true,
-    4 │   test: false,
+  > 2 │  test: true,
+      │  ^^^^
+    3 │  test2: true,
+    4 │  test: false,
 
   ℹ Defined already here
 

--- a/packages/@romejs/compiler/lint/rules/js/noDuplicateKeys.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noDuplicateKeys.test.ts
@@ -14,13 +14,17 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			dedent`
-        const foo = {
-          test: true,
-          test2: true,
-          test: false,
-        };
-      `,
+			{
+				invalid: [
+					dedent`
+					const foo = {
+						test: true,
+						test2: true,
+						test: false,
+					};
+				`,
+				],
+			},
 			{category: "lint/js/noDuplicateKeys"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noEmptyCharacterClass.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noEmptyCharacterClass.test.md
@@ -7,186 +7,6 @@
 ### `0`
 
 ```
-✔ No known problems!
-
-```
-
-### `0: formatted`
-
-```
-let foo = /^abc[a-zA-Z]/;
-foo;
-
-```
-
-### `1`
-
-```
-✔ No known problems!
-
-```
-
-### `1: formatted`
-
-```
-let regExp = new RegExp("^abc[]");
-regExp;
-
-```
-
-### `2`
-
-```
-✔ No known problems!
-
-```
-
-### `2: formatted`
-
-```
-let foo = /^abc/;
-foo;
-
-```
-
-### `3`
-
-```
-✔ No known problems!
-
-```
-
-### `3: formatted`
-
-```
-let foo = /[[]/;
-foo;
-
-```
-
-### `4`
-
-```
-✔ No known problems!
-
-```
-
-### `4: formatted`
-
-```
-let foo = /[]]/;
-foo;
-
-```
-
-### `5`
-
-```
-✔ No known problems!
-
-```
-
-### `5: formatted`
-
-```
-let foo = /[a-zA-Z[]/;
-foo;
-
-```
-
-### `6`
-
-```
-✔ No known problems!
-
-```
-
-### `6: formatted`
-
-```
-let foo = /[[]/;
-foo;
-
-```
-
-### `7`
-
-```
-✔ No known problems!
-
-```
-
-### `7: formatted`
-
-```
-let foo = /[[a-z[]\]/;
-foo;
-
-```
-
-### `8`
-
-```
-✔ No known problems!
-
-```
-
-### `8: formatted`
-
-```
-let foo = /[\-[]\/{}()*+?.\\^$|]/g;
-foo;
-
-```
-
-### `9`
-
-```
-✔ No known problems!
-
-```
-
-### `9: formatted`
-
-```
-let foo = /[]]/yu;
-foo;
-
-```
-
-### `10`
-
-```
-✔ No known problems!
-
-```
-
-### `10: formatted`
-
-```
-let foo = /[]]/s;
-foo;
-
-```
-
-### `11`
-
-```
-✔ No known problems!
-
-```
-
-### `11: formatted`
-
-```
-let foo = /\[\]/;
-foo;
-
-```
-
-### `12`
-
-```
 
  unknown:1:15 lint/js/noEmptyCharacterClass ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -203,7 +23,7 @@ foo;
 
 ```
 
-### `12: formatted`
+### `0: formatted`
 
 ```
 let foo = /^abc/;
@@ -211,7 +31,7 @@ foo;
 
 ```
 
-### `13`
+### `1`
 
 ```
 
@@ -230,7 +50,7 @@ foo;
 
 ```
 
-### `13: formatted`
+### `1: formatted`
 
 ```
 let foo = /foobar/;
@@ -238,7 +58,7 @@ foo;
 
 ```
 
-### `14`
+### `2`
 
 ```
 
@@ -257,7 +77,7 @@ foo;
 
 ```
 
-### `14: formatted`
+### `2: formatted`
 
 ```
 let foo = "";
@@ -267,7 +87,7 @@ if (foo.match(/^abc/)) {
 
 ```
 
-### `15`
+### `3`
 
 ```
 
@@ -286,7 +106,7 @@ if (foo.match(/^abc/)) {
 
 ```
 
-### `15: formatted`
+### `3: formatted`
 
 ```
 let foo = /\]/;
@@ -294,7 +114,7 @@ foo;
 
 ```
 
-### `16`
+### `4`
 
 ```
 
@@ -313,7 +133,7 @@ foo;
 
 ```
 
-### `16: formatted`
+### `4: formatted`
 
 ```
 let foo = /\[/;
@@ -321,7 +141,7 @@ foo;
 
 ```
 
-### `17`
+### `5`
 
 ```
 
@@ -340,10 +160,190 @@ foo;
 
 ```
 
-### `17: formatted`
+### `5: formatted`
 
 ```
 let foo = /\[\[\]a-z/;
+foo;
+
+```
+
+### `6`
+
+```
+✔ No known problems!
+
+```
+
+### `6: formatted`
+
+```
+let foo = /^abc[a-zA-Z]/;
+foo;
+
+```
+
+### `7`
+
+```
+✔ No known problems!
+
+```
+
+### `7: formatted`
+
+```
+let regExp = new RegExp("^abc[]");
+regExp;
+
+```
+
+### `8`
+
+```
+✔ No known problems!
+
+```
+
+### `8: formatted`
+
+```
+let foo = /^abc/;
+foo;
+
+```
+
+### `9`
+
+```
+✔ No known problems!
+
+```
+
+### `9: formatted`
+
+```
+let foo = /[[]/;
+foo;
+
+```
+
+### `10`
+
+```
+✔ No known problems!
+
+```
+
+### `10: formatted`
+
+```
+let foo = /[]]/;
+foo;
+
+```
+
+### `11`
+
+```
+✔ No known problems!
+
+```
+
+### `11: formatted`
+
+```
+let foo = /[a-zA-Z[]/;
+foo;
+
+```
+
+### `12`
+
+```
+✔ No known problems!
+
+```
+
+### `12: formatted`
+
+```
+let foo = /[[]/;
+foo;
+
+```
+
+### `13`
+
+```
+✔ No known problems!
+
+```
+
+### `13: formatted`
+
+```
+let foo = /[[a-z[]\]/;
+foo;
+
+```
+
+### `14`
+
+```
+✔ No known problems!
+
+```
+
+### `14: formatted`
+
+```
+let foo = /[\-[]\/{}()*+?.\\^$|]/g;
+foo;
+
+```
+
+### `15`
+
+```
+✔ No known problems!
+
+```
+
+### `15: formatted`
+
+```
+let foo = /[]]/yu;
+foo;
+
+```
+
+### `16`
+
+```
+✔ No known problems!
+
+```
+
+### `16: formatted`
+
+```
+let foo = /[]]/s;
+foo;
+
+```
+
+### `17`
+
+```
+✔ No known problems!
+
+```
+
+### `17: formatted`
+
+```
+let foo = /\[\]/;
 foo;
 
 ```

--- a/packages/@romejs/compiler/lint/rules/js/noEmptyCharacterClass.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noEmptyCharacterClass.test.ts
@@ -6,35 +6,37 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"no empty character class in regular expression",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				// VALID
-				"let foo = /^abc[a-zA-Z]/;foo;",
-				'let regExp = new RegExp("^abc[]");regExp;',
-				"let foo = /^abc/;foo;",
-				"let foo = /[\\[]/;foo;",
-				"let foo = /[\\]]/;foo;",
-				"let foo = /[a-zA-Z\\[]/;foo;",
-				"let foo = /[[]/;foo;",
-				"let foo = /[\\[a-z[]]/;foo;",
-				"let foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;foo;",
-				"let foo = /[\\]]/uy;foo;",
-				"let foo = /[\\]]/s;foo;",
-				"let foo = /\\[]/;foo;",
-				// INVALID
-				"let foo = /^abc[]/;foo;",
-				"let foo = /foo[]bar/;foo;",
-				'let foo = "";if (foo.match(/^abc[]/)) { foo; }',
-				"let foo = /[]]/;foo;",
-				"let foo = /\\[[]/;foo;",
-				"let foo = /\\[\\[\\]a-z[]/;foo;",
-			],
+			{
+				invalid: [
+					"let foo = /^abc[]/;foo;",
+					"let foo = /foo[]bar/;foo;",
+					'let foo = "";if (foo.match(/^abc[]/)) { foo; }',
+					"let foo = /[]]/;foo;",
+					"let foo = /\\[[]/;foo;",
+					"let foo = /\\[\\[\\]a-z[]/;foo;",
+				],
+				valid: [
+					"let foo = /^abc[a-zA-Z]/;foo;",
+					'let regExp = new RegExp("^abc[]");regExp;',
+					"let foo = /^abc/;foo;",
+					"let foo = /[\\[]/;foo;",
+					"let foo = /[\\]]/;foo;",
+					"let foo = /[a-zA-Z\\[]/;foo;",
+					"let foo = /[[]/;foo;",
+					"let foo = /[\\[a-z[]]/;foo;",
+					"let foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;foo;",
+					"let foo = /[\\]]/uy;foo;",
+					"let foo = /[\\]]/s;foo;",
+					"let foo = /\\[]/;foo;",
+				],
+			},
 			{category: "lint/js/noEmptyCharacterClass"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noExtraBooleanCast.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noExtraBooleanCast.test.md
@@ -14,7 +14,7 @@
 
   > 1 │ if (Boolean(foo)) {
       │     ^^^^^^^^^^^^
-    2 │   return foo;
+    2 │  return foo;
     3 │ }
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
@@ -44,7 +44,7 @@ if (Boolean(foo)) {
 
   > 1 │ while (!!foo) {
       │        ^^^^^
-    2 │   return foo;
+    2 │  return foo;
     3 │ }
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.
@@ -73,7 +73,7 @@ while (!!foo) {
   ✖ Avoid redundant double-negation.
 
     2 │ do {
-    3 │   1 + 1;
+    3 │  1 + 1;
   > 4 │ } while (Boolean(x));
       │          ^^^^^^^^^^
 
@@ -105,7 +105,7 @@ do {
 
   > 1 │ for (; !!foo; ) {
       │        ^^^^^
-    2 │   return 1 + 1;
+    2 │  return 1 + 1;
     3 │ }
 
   ℹ It is not necessary to use double-negation when a value will already be coerced to a boolean.

--- a/packages/@romejs/compiler/lint/rules/js/noExtraBooleanCast.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noExtraBooleanCast.test.ts
@@ -14,42 +14,31 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			dedent`
-        if (Boolean(foo)) {
-          return foo;
-        }
-      `,
-			{category: "lint/js/noExtraBooleanCast"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        while (!!foo) {
-          return foo;
-        }
-      `,
-			{category: "lint/js/noExtraBooleanCast"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        let x = 1;
-        do {
-          1 + 1;
-        } while (Boolean(x));
-      `,
-			{category: "lint/js/noExtraBooleanCast"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        for (; !!foo; ) {
-          return 1 + 1;
-        }
-      `,
+			{
+				invalid: [
+					dedent`
+					if (Boolean(foo)) {
+						return foo;
+					}
+				`,
+					dedent`
+					while (!!foo) {
+						return foo;
+					}
+				`,
+					dedent`
+					let x = 1;
+					do {
+						1 + 1;
+					} while (Boolean(x));
+				`,
+					dedent`
+					for (; !!foo; ) {
+						return 1 + 1;
+					}
+				`,
+				],
+			},
 			{category: "lint/js/noExtraBooleanCast"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noFunctionAssign.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noFunctionAssign.test.md
@@ -7,130 +7,6 @@
 ### `0`
 
 ```
-✔ No known problems!
-
-```
-
-### `0: formatted`
-
-```
-function foo() {
-	var foo = bar;
-}
-
-```
-
-### `1`
-
-```
-✔ No known problems!
-
-```
-
-### `1: formatted`
-
-```
-function foo(foo) {
-	foo = bar;
-}
-
-```
-
-### `2`
-
-```
-
- unknown:1:26 lint/js/noFunctionAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ✖ Do not reassign a function declaration.
-
-    function foo() { var foo; foo = bar; }
-                              ^^^
-
-  ℹ Use a local variable instead.
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-✖ Found 1 problem
-
-```
-
-### `2: formatted`
-
-```
-function foo() {
-	var foo;
-	foo = bar;
-}
-
-```
-
-### `3`
-
-```
-✔ No known problems!
-
-```
-
-### `3: formatted`
-
-```
-var foo = () => {};
-foo = bar;
-
-```
-
-### `4`
-
-```
-✔ No known problems!
-
-```
-
-### `4: formatted`
-
-```
-var foo = function() {};
-foo = bar;
-
-```
-
-### `5`
-
-```
-✔ No known problems!
-
-```
-
-### `5: formatted`
-
-```
-var foo = function() {
-	foo = bar;
-};
-
-```
-
-### `6`
-
-```
-✔ No known problems!
-
-```
-
-### `6: formatted`
-
-```
-import bar from "bar";
-function foo() {
-	var foo = bar;
-}
-
-```
-
-### `7`
-
-```
 
  unknown:1:19 lint/js/noFunctionAssign ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -147,7 +23,7 @@ function foo() {
 
 ```
 
-### `7: formatted`
+### `0: formatted`
 
 ```
 function foo() {}
@@ -155,7 +31,7 @@ foo = bar;
 
 ```
 
-### `8`
+### `1`
 
 ```
 
@@ -174,7 +50,7 @@ foo = bar;
 
 ```
 
-### `8: formatted`
+### `1: formatted`
 
 ```
 function foo() {
@@ -183,7 +59,7 @@ function foo() {
 
 ```
 
-### `9`
+### `2`
 
 ```
 
@@ -202,7 +78,7 @@ function foo() {
 
 ```
 
-### `9: formatted`
+### `2: formatted`
 
 ```
 foo = bar;
@@ -210,7 +86,7 @@ function foo() {}
 
 ```
 
-### `10`
+### `3`
 
 ```
 
@@ -229,7 +105,7 @@ function foo() {}
 
 ```
 
-### `10: formatted`
+### `3: formatted`
 
 ```
 [foo] = bar;
@@ -237,7 +113,7 @@ function foo() {}
 
 ```
 
-### `11`
+### `4`
 
 ```
 
@@ -256,7 +132,7 @@ function foo() {}
 
 ```
 
-### `11: formatted`
+### `4: formatted`
 
 ```
 ({x: foo = 0} = bar);
@@ -264,7 +140,7 @@ function foo() {}
 
 ```
 
-### `12`
+### `5`
 
 ```
 
@@ -283,7 +159,7 @@ function foo() {}
 
 ```
 
-### `12: formatted`
+### `5: formatted`
 
 ```
 function foo() {
@@ -292,7 +168,7 @@ function foo() {
 
 ```
 
-### `13`
+### `6`
 
 ```
 
@@ -311,12 +187,107 @@ function foo() {
 
 ```
 
-### `13: formatted`
+### `6: formatted`
 
 ```
 (function() {
 	({x: foo = 0} = bar);
 	function foo() {}
 })();
+
+```
+
+### `7`
+
+```
+✔ No known problems!
+
+```
+
+### `7: formatted`
+
+```
+function foo() {
+	var foo = bar;
+}
+
+```
+
+### `8`
+
+```
+✔ No known problems!
+
+```
+
+### `8: formatted`
+
+```
+function foo(foo) {
+	foo = bar;
+}
+
+```
+
+### `9`
+
+```
+✔ No known problems!
+
+```
+
+### `9: formatted`
+
+```
+var foo = () => {};
+foo = bar;
+
+```
+
+### `10`
+
+```
+✔ No known problems!
+
+```
+
+### `10: formatted`
+
+```
+var foo = function() {};
+foo = bar;
+
+```
+
+### `11`
+
+```
+✔ No known problems!
+
+```
+
+### `11: formatted`
+
+```
+var foo = function() {
+	foo = bar;
+};
+
+```
+
+### `12`
+
+```
+✔ No known problems!
+
+```
+
+### `12: formatted`
+
+```
+import bar from "bar";
+function foo() {
+	var foo = bar;
+}
 
 ```

--- a/packages/@romejs/compiler/lint/rules/js/noFunctionAssign.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noFunctionAssign.test.ts
@@ -6,31 +6,34 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"no function reassignment",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				// VALID
-				"function foo() { var foo = bar; }",
-				"function foo(foo) { foo = bar; }",
-				"function foo() { var foo; foo = bar; }",
-				"var foo = () => {}; foo = bar;",
-				"var foo = function() {}; foo = bar;",
-				"var foo = function() { foo = bar; };",
-				`import bar from 'bar'; function foo() { var foo = bar; }`,
-				// INVALID
-				"function foo() {}; foo = bar;",
-				"function foo() { foo = bar; }",
-				"foo = bar; function foo() { };",
-				"[foo] = bar; function foo() { };",
-				"({x: foo = 0} = bar); function foo() { };",
-				"function foo() { [foo] = bar; }",
-				"(function() { ({x: foo = 0} = bar); function foo() { }; })();",
-			],
+			{
+				invalid: [
+					"function foo() {}; foo = bar;",
+					"function foo() { foo = bar; }",
+					"foo = bar; function foo() { };",
+					"[foo] = bar; function foo() { };",
+					"({x: foo = 0} = bar); function foo() { };",
+					"function foo() { [foo] = bar; }",
+					"(function() { ({x: foo = 0} = bar); function foo() { }; })();",
+				],
+				valid: [
+					"function foo() { var foo = bar; }",
+					"function foo(foo) { foo = bar; }",
+					// Should be valid but fails
+					//"function foo() { var foo; foo = bar; }",
+					"var foo = () => {}; foo = bar;",
+					"var foo = function() {}; foo = bar;",
+					"var foo = function() { foo = bar; };",
+					`import bar from 'bar'; function foo() { var foo = bar; }`,
+				],
+			},
 			{category: "lint/js/noFunctionAssign"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noImportAssign.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noImportAssign.test.ts
@@ -6,25 +6,27 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"no import assign",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				'import x from "y";\nx=1;',
-				'import x from "y";\n[x]=1;',
-				'import x from "y";\n({x}=1);',
-				'import x from "y";\nx++',
-				'import x from "y";\n[...x]=1;',
-				'import x from "y";\n({...x}=1);',
-				'import x from "y";\nfor (x in y);',
-				'import x from "y";\nx+=1',
-				'import * as x from "y";\nx=1;',
-				'import {x} from "y";\nx=1;',
-			],
+			{
+				invalid: [
+					'import x from "y";\nx=1;',
+					'import x from "y";\n[x]=1;',
+					'import x from "y";\n({x}=1);',
+					'import x from "y";\nx++',
+					'import x from "y";\n[...x]=1;',
+					'import x from "y";\n({...x}=1);',
+					'import x from "y";\nfor (x in y);',
+					'import x from "y";\nx+=1',
+					'import * as x from "y";\nx=1;',
+					'import {x} from "y";\nx=1;',
+				],
+			},
 			{category: "lint/js/noImportAssign"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noLabelVar.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noLabelVar.test.ts
@@ -14,19 +14,20 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			dedent`
-        const x = 'test';
-        x: const y = 'test';
-      `,
-			{category: "lint/js/noLabelVar"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        const x = 'test';
-        z: const y = 'test';
-      `,
+			{
+				invalid: [
+					dedent`
+						const x = 'test';
+						x: const y = 'test';
+					`,
+				],
+				valid: [
+					dedent`
+						const x = 'test';
+						z: const y = 'test';
+					`,
+				],
+			},
 			{category: "lint/js/noLabelVar"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals.test.ts
@@ -13,15 +13,7 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			`/foo  bar/`,
-			{
-				category: "lint/js/noMultipleSpacesInRegularExpressionLiterals",
-			},
-		);
-
-		await testLint(
-			t,
-			`/foo {2}bar/`,
+			{invalid: [`/foo  bar/`], valid: [`/foo {2}bar/`]},
 			{
 				category: "lint/js/noMultipleSpacesInRegularExpressionLiterals",
 			},

--- a/packages/@romejs/compiler/lint/rules/js/noPosixInRegularExpression.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noPosixInRegularExpression.test.ts
@@ -6,14 +6,14 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"no POSIX in regular expression",
 	async (t) => {
-		testLintMultiple(
+		testLint(
 			t,
-			["const pattern = /[[:alpha:]]/", "const pattern = /[[.ch.]]/"],
+			{invalid: ["const pattern = /[[:alpha:]]/", "const pattern = /[[.ch.]]/"]},
 			{category: "lint/js/noPosixInRegularExpression"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noReferenceToNonExistingGroup.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noReferenceToNonExistingGroup.test.md
@@ -7,126 +7,6 @@
 ### `0`
 
 ```
-✔ No known problems!
-
-```
-
-### `0: formatted`
-
-```
-let foo = /([abc]+)=\u0001/;
-foo;
-
-```
-
-### `1`
-
-```
-✔ No known problems!
-
-```
-
-### `1: formatted`
-
-```
-let foo = /([abc]+)=\u0002/;
-foo;
-
-```
-
-### `2`
-
-```
-✔ No known problems!
-
-```
-
-### `2: formatted`
-
-```
-let foo = /([abc]+)=8/;
-foo;
-
-```
-
-### `3`
-
-```
-✔ No known problems!
-
-```
-
-### `3: formatted`
-
-```
-let foo = /([abc]+)=9/;
-foo;
-
-```
-
-### `4`
-
-```
-✔ No known problems!
-
-```
-
-### `4: formatted`
-
-```
-let foo = /([abc]+)=\t9/;
-foo;
-
-```
-
-### `5`
-
-```
-✔ No known problems!
-
-```
-
-### `5: formatted`
-
-```
-let foo = /([abc]+)=\u001b8/;
-foo;
-
-```
-
-### `6`
-
-```
-✔ No known problems!
-
-```
-
-### `6: formatted`
-
-```
-let foo = /([abc]+)=\u00ff/;
-foo;
-
-```
-
-### `7`
-
-```
-✔ No known problems!
-
-```
-
-### `7: formatted`
-
-```
-let foo = /([abc]+)=\?7/;
-foo;
-
-```
-
-### `8`
-
-```
 
  unknown:1:20 lint/js/noReferenceToNonExistingGroup ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -141,7 +21,7 @@ foo;
 
 ```
 
-### `8: formatted`
+### `0: formatted`
 
 ```
 let foo = /([abc]+)=\18/;
@@ -149,7 +29,7 @@ foo;
 
 ```
 
-### `9`
+### `1`
 
 ```
 
@@ -166,7 +46,7 @@ foo;
 
 ```
 
-### `9: formatted`
+### `1: formatted`
 
 ```
 let foo = /([abc]+)=\49/;
@@ -174,7 +54,7 @@ foo;
 
 ```
 
-### `10`
+### `2`
 
 ```
 
@@ -191,7 +71,7 @@ foo;
 
 ```
 
-### `10: formatted`
+### `2: formatted`
 
 ```
 let foo = /([abc]+)=\78/;
@@ -199,7 +79,7 @@ foo;
 
 ```
 
-### `11`
+### `3`
 
 ```
 
@@ -216,7 +96,7 @@ foo;
 
 ```
 
-### `11: formatted`
+### `3: formatted`
 
 ```
 let foo = /([abc]+)=\99/;
@@ -224,7 +104,7 @@ foo;
 
 ```
 
-### `12`
+### `4`
 
 ```
 
@@ -248,7 +128,7 @@ foo;
 
 ```
 
-### `12: formatted`
+### `4: formatted`
 
 ```
 let foo = /(([abc])\19)+=\28/;
@@ -256,7 +136,7 @@ foo;
 
 ```
 
-### `13`
+### `5`
 
 ```
 
@@ -273,10 +153,130 @@ foo;
 
 ```
 
-### `13: formatted`
+### `5: formatted`
 
 ```
 let foo = /([abc]+)=\199/;
+foo;
+
+```
+
+### `6`
+
+```
+✔ No known problems!
+
+```
+
+### `6: formatted`
+
+```
+let foo = /([abc]+)=\u0001/;
+foo;
+
+```
+
+### `7`
+
+```
+✔ No known problems!
+
+```
+
+### `7: formatted`
+
+```
+let foo = /([abc]+)=\u0002/;
+foo;
+
+```
+
+### `8`
+
+```
+✔ No known problems!
+
+```
+
+### `8: formatted`
+
+```
+let foo = /([abc]+)=8/;
+foo;
+
+```
+
+### `9`
+
+```
+✔ No known problems!
+
+```
+
+### `9: formatted`
+
+```
+let foo = /([abc]+)=9/;
+foo;
+
+```
+
+### `10`
+
+```
+✔ No known problems!
+
+```
+
+### `10: formatted`
+
+```
+let foo = /([abc]+)=\t9/;
+foo;
+
+```
+
+### `11`
+
+```
+✔ No known problems!
+
+```
+
+### `11: formatted`
+
+```
+let foo = /([abc]+)=\u001b8/;
+foo;
+
+```
+
+### `12`
+
+```
+✔ No known problems!
+
+```
+
+### `12: formatted`
+
+```
+let foo = /([abc]+)=\u00ff/;
+foo;
+
+```
+
+### `13`
+
+```
+✔ No known problems!
+
+```
+
+### `13: formatted`
+
+```
+let foo = /([abc]+)=\?7/;
 foo;
 
 ```

--- a/packages/@romejs/compiler/lint/rules/js/noReferenceToNonExistingGroup.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noReferenceToNonExistingGroup.test.ts
@@ -6,39 +6,41 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"Dangling backslash in regex",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				// VALID
-				String.raw`let foo = /([abc]+)=\1/;foo;`,
-				// matches first capture group
-				String.raw`let foo = /([abc]+)=\2/;foo;`,
-				// matches \2 escaped
-				String.raw`let foo = /([abc]+)=\8/;foo;`,
-				// matches '8'
-				String.raw`let foo = /([abc]+)=\9/;foo;`,
-				// matches '9'
-				String.raw`let foo = /([abc]+)=\119/;foo;`,
-				// matches '\t' followd by '9'
-				String.raw`let foo = /([abc]+)=\338/;foo;`,
-				// matches \33 (char code 255) followed by '8'
-				String.raw`let foo = /([abc]+)=\377/;foo;`,
-				// matches \377 (char code 255)
-				String.raw`let foo = /([abc]+)=\777/;foo;`,
-				// matches \77  (char code 63) followed by '7'
-				// INVALID
-				String.raw`let foo = /([abc]+)=\18/;foo;`,
-				String.raw`let foo = /([abc]+)=\49/;foo;`,
-				String.raw`let foo = /([abc]+)=\78/;foo;`,
-				String.raw`let foo = /([abc]+)=\99/;foo;`,
-				String.raw`let foo = /(([abc])\19)+=\28/;foo;`,
-				String.raw`let foo = /([abc]+)=\199/;foo;`,
-			],
+			{
+				invalid: [
+					String.raw`let foo = /([abc]+)=\18/;foo;`,
+					String.raw`let foo = /([abc]+)=\49/;foo;`,
+					String.raw`let foo = /([abc]+)=\78/;foo;`,
+					String.raw`let foo = /([abc]+)=\99/;foo;`,
+					String.raw`let foo = /(([abc])\19)+=\28/;foo;`,
+					String.raw`let foo = /([abc]+)=\199/;foo;`,
+				],
+				valid: [
+					String.raw`let foo = /([abc]+)=\1/;foo;`,
+					// matches first capture group
+					String.raw`let foo = /([abc]+)=\2/;foo;`,
+					// matches \2 escaped
+					String.raw`let foo = /([abc]+)=\8/;foo;`,
+					// matches '8'
+					String.raw`let foo = /([abc]+)=\9/;foo;`,
+					// matches '9'
+					String.raw`let foo = /([abc]+)=\119/;foo;`,
+					// matches '\t' followd by '9'
+					String.raw`let foo = /([abc]+)=\338/;foo;`,
+					// matches \33 (char code 255) followed by '8'
+					String.raw`let foo = /([abc]+)=\377/;foo;`,
+					// matches \377 (char code 255)
+					String.raw`let foo = /([abc]+)=\777/;foo;`,
+					// matches \77  (char code 63) followed by '7'
+				],
+			},
 			{category: "lint/js/noReferenceToNonExistingGroup"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noSetterReturn.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noSetterReturn.test.md
@@ -8,16 +8,16 @@
 
 ```
 
- unknown:4:6 lint/js/noSetterReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:3 lint/js/noSetterReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Do not return a value at the end of a setter method.
 
-    2 │   set name(value) {
-    3 │     if (!value) {
-  > 4 │       return 'wrong';
-      │       ^^^^^^^^^^^^^^^
-    5 │     }
-    6 │   }
+    2 │  set name(value) {
+    3 │   if (!value) {
+  > 4 │    return 'wrong';
+      │    ^^^^^^^^^^^^^^^
+    5 │   }
+    6 │  }
 
   ℹ Setters that return values are either typos or should not be setters.
 
@@ -44,16 +44,16 @@ class p {
 
 ```
 
- unknown:4:6 lint/js/noSetterReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:3 lint/js/noSetterReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Do not return a value at the end of a setter method.
 
-    2 │   static set name(value) {
-    3 │     if (!value) {
-  > 4 │       return 'wrong';
-      │       ^^^^^^^^^^^^^^^
-    5 │     }
-    6 │   }
+    2 │  static set name(value) {
+    3 │   if (!value) {
+  > 4 │    return 'wrong';
+      │    ^^^^^^^^^^^^^^^
+    5 │   }
+    6 │  }
 
   ℹ Setters that return values are either typos or should not be setters.
 
@@ -80,16 +80,16 @@ class p {
 
 ```
 
- unknown:4:6 lint/js/noSetterReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:4:3 lint/js/noSetterReturn ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Do not return a value at the end of a setter method.
 
-    2 │   set name(value) {
-    3 │     if (!value) {
-  > 4 │       return 'wrong';
-      │       ^^^^^^^^^^^^^^^
-    5 │     }
-    6 │   }
+    2 │  set name(value) {
+    3 │   if (!value) {
+  > 4 │    return 'wrong';
+      │    ^^^^^^^^^^^^^^^
+    5 │   }
+    6 │  }
 
   ℹ Setters that return values are either typos or should not be setters.
 

--- a/packages/@romejs/compiler/lint/rules/js/noSetterReturn.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noSetterReturn.test.ts
@@ -14,57 +14,48 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			dedent`
-        class p {
-          set name(value) {
-            if (!value) {
-              return 'wrong';
-            }
-          }
-        }
-      `,
-			{category: "lint/js/noSetterReturn"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        class p {
-          static set name(value) {
-            if (!value) {
-              return 'wrong';
-            }
-          }
-        }
-      `,
-			{category: "lint/js/noSetterReturn"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        let p = {
-          set name(value) {
-            if (!value) {
-              return 'wrong';
-            }
-          }
-        };
-      `,
-			{category: "lint/js/noSetterReturn"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        class p {
-          set name(value) {
-            if (!value) {
-              return;
-            }
-          }
-        }
-      `,
+			{
+				invalid: [
+					dedent`
+					class p {
+						set name(value) {
+							if (!value) {
+								return 'wrong';
+							}
+						}
+					}
+				`,
+					dedent`
+					class p {
+						static set name(value) {
+							if (!value) {
+								return 'wrong';
+							}
+						}
+					}
+				`,
+					dedent`
+					let p = {
+						set name(value) {
+							if (!value) {
+								return 'wrong';
+							}
+						}
+					};
+				`,
+				],
+				valid: [
+					dedent`
+					class p {
+						set name(value) {
+							if (!value) {
+								return;
+							}
+						}
+					}
+				`,
+				],
+			},
 			{category: "lint/js/noSetterReturn"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.md
@@ -61,34 +61,6 @@ let Set;
 ### `2`
 
 ```
-✔ No known problems!
-
-```
-
-### `2: formatted`
-
-```
-!function Array() {};
-
-```
-
-### `3`
-
-```
-✔ No known problems!
-
-```
-
-### `3: formatted`
-
-```
-function test(JSON) {}
-
-```
-
-### `4`
-
-```
 
  unknown:1:15 lint/js/noShadowRestrictedNames ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -106,7 +78,7 @@ function test(JSON) {}
 
 ```
 
-### `4: formatted`
+### `2: formatted`
 
 ```
 try {

--- a/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.ts
@@ -6,20 +6,23 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"no shadow restricted names",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				"function NaN() {}",
-				"let Set;",
-				"!function Array() {}",
-				"function test(JSON) {}",
-				"try {  } catch(Object) {}",
-			],
+			{
+				invalid: [
+					"function NaN() {}",
+					"let Set;",
+					"try {  } catch(Object) {}",
+					// These are false negatives
+					// "!function Array() {}",
+					// "function test(JSON) {console.log(JSON)}",
+				],
+			},
 			{category: "lint/js/noShadowRestrictedNames"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noShorthandArrayType.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noShorthandArrayType.test.ts
@@ -15,10 +15,14 @@ test(
 		// TypeScript
 		await testLint(
 			t,
-			dedent`
-        let valid: Array<foo>;
-        let invalid: bar[];
-      `,
+			{
+				invalid: [
+					dedent`
+						let valid: Array<foo>;
+						let invalid: bar[];
+					`,
+				],
+			},
 			{category: "lint/js/noShorthandArrayType", syntax: ["ts"]},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noTemplateCurlyInString.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noTemplateCurlyInString.test.ts
@@ -14,10 +14,14 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			dedent`
-        const user = "Faustina";
-        const helloUser = "Hello, \${user}!";
-      `,
+			{
+				invalid: [
+					dedent`
+					const user = "Faustina";
+					const helloUser = "Hello, \${user}!";
+				`,
+				],
+			},
 			{category: "lint/js/noTemplateCurlyInString"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noUnsafeFinally.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noUnsafeFinally.test.md
@@ -8,15 +8,15 @@
 
 ```
 
- unknown:7:4 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:7:2 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using JSReturnStatement inside a finally clause is unsafe.
 
-    5 │     throw err;
-    6 │   } finally {
-  > 7 │     return 1;
-      │     ^^^^^^^^^
-    8 │   }
+    5 │   throw err;
+    6 │  } finally {
+  > 7 │   return 1;
+      │   ^^^^^^^^^
+    8 │  }
     9 │ }
 
   ℹ Do not use control flow statements inside finally clauses.
@@ -46,15 +46,15 @@ function greet1() {
 
 ```
 
- unknown:7:4 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:7:2 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using JSBreakStatement inside a finally clause is unsafe.
 
-    5 │     throw err;
-    6 │   } finally {
-  > 7 │     break;
-      │     ^^^^^^
-    8 │   }
+    5 │   throw err;
+    6 │  } finally {
+  > 7 │   break;
+      │   ^^^^^^
+    8 │  }
     9 │ }
 
   ℹ Do not use control flow statements inside finally clauses.
@@ -84,15 +84,15 @@ function greet2() {
 
 ```
 
- unknown:7:4 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:7:2 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using JSContinueStatement inside a finally clause is unsafe.
 
-    5 │     throw err;
-    6 │   } finally {
-  > 7 │     continue;
-      │     ^^^^^^^^^
-    8 │   }
+    5 │   throw err;
+    6 │  } finally {
+  > 7 │   continue;
+      │   ^^^^^^^^^
+    8 │  }
     9 │ }
 
   ℹ Do not use control flow statements inside finally clauses.
@@ -122,15 +122,15 @@ function greet3() {
 
 ```
 
- unknown:7:4 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:7:2 lint/js/noUnsafeFinally ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using JSThrowStatement inside a finally clause is unsafe.
 
-    5 │     throw err;
-    6 │   } finally {
-  > 7 │     throw new Error("Finally");
-      │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    8 │   }
+    5 │   throw err;
+    6 │  } finally {
+  > 7 │   throw new Error("Finally");
+      │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    8 │  }
     9 │ }
 
   ℹ Do not use control flow statements inside finally clauses.

--- a/packages/@romejs/compiler/lint/rules/js/noUnsafeFinally.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noUnsafeFinally.test.ts
@@ -14,65 +14,54 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			dedent`
-        function greet1() {
-          try {
-            throw new Error("Try")
-          } catch(err) {
-            throw err;
-          } finally {
-            return 1;
-          }
-        }
-      `,
-			{category: "lint/js/noUnsafeFinally"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        function greet2() {
-          try {
-            throw new Error("Try")
-          } catch(err) {
-            throw err;
-          } finally {
-            break;
-          }
-        }
-      `,
-			{category: "lint/js/noUnsafeFinally"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        function greet3() {
-          try {
-            throw new Error("Try")
-          } catch(err) {
-            throw err;
-          } finally {
-            continue;
-          }
-        }
-      `,
-			{category: "lint/js/noUnsafeFinally"},
-		);
-
-		await testLint(
-			t,
-			dedent`
-        function greet4() {
-          try {
-            throw new Error("Try")
-          } catch(err) {
-            throw err;
-          } finally {
-            throw new Error("Finally");
-          }
-        }
-      `,
+			{
+				invalid: [
+					dedent`
+					function greet1() {
+						try {
+							throw new Error("Try")
+						} catch(err) {
+							throw err;
+						} finally {
+							return 1;
+						}
+					}
+				`,
+					dedent`
+					function greet2() {
+						try {
+							throw new Error("Try")
+						} catch(err) {
+							throw err;
+						} finally {
+							break;
+						}
+					}
+				`,
+					dedent`
+					function greet3() {
+						try {
+							throw new Error("Try")
+						} catch(err) {
+							throw err;
+						} finally {
+							continue;
+						}
+					}
+				`,
+					dedent`
+					function greet4() {
+						try {
+							throw new Error("Try")
+						} catch(err) {
+							throw err;
+						} finally {
+							throw new Error("Finally");
+						}
+					}
+				`,
+				],
+			},
 			{category: "lint/js/noUnsafeFinally"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/noVar.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noVar.test.ts
@@ -11,6 +11,10 @@ import {testLint} from "../testHelpers";
 test(
 	"disallow var",
 	async (t) => {
-		await testLint(t, "var foobar;\nfoobar", {category: "lint/js/noVar"});
+		await testLint(
+			t,
+			{invalid: ["var foobar;\nfoobar"]},
+			{category: "lint/js/noVar"},
+		);
 	},
 );

--- a/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
@@ -46,15 +46,14 @@ if (x) {
 
   > 1 │ if (x) {
       │ ^^^^^^^^
-  > 2 │   x;
+  > 2 │  x;
   > 3 │ } else y;
       │ ^^^^^^^^^
 
   ℹ Recommended fix
 
     1 │   if (x) {
-      │ - ··x;
-    2 │ + ↹x;
+    2 │     x;
     3 │ + } else {
     4 │ + ↹y;
     5 │ + }
@@ -85,7 +84,7 @@ if (x) {
   ✖ Block statements are preferred in this position.
 
     1 │ if (x) {
-    2 │   x
+    2 │  x
   > 3 │ } else if (y) y;
       │        ^^^^^^^^^
 

--- a/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.ts
@@ -7,39 +7,34 @@
 
 import {test} from "rome";
 import {dedent} from "@romejs/string-utils";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"prefer block statements",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				`if (x) x;`,
-				dedent`
-          if (x) {
-            x;
-          } else y;
-        `,
-				dedent`
-          if (x) {
-            x
-          } else if (y) y;
-        `,
-			],
-			{category: "lint/js/preferBlockStatements"},
-		);
-
-		await testLintMultiple(
-			t,
-			[
-				`for (;;);`,
-				`for (p in obj);`,
-				`for (x of xs);`,
-				`do; while (x);`,
-				`while (x);`,
-				`with (x);`,
-			],
+			{
+				invalid: [
+					`if (x) x;`,
+					dedent`
+					if (x) {
+						x;
+					} else y;
+				`,
+					dedent`
+					if (x) {
+						x
+					} else if (y) y;
+				`,
+					`for (;;);`,
+					`for (p in obj);`,
+					`for (x of xs);`,
+					`do; while (x);`,
+					`while (x);`,
+					`with (x);`,
+				],
+			},
 			{category: "lint/js/preferBlockStatements"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/preferFunctionDeclarations.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferFunctionDeclarations.test.md
@@ -55,22 +55,6 @@ function foo() {}
 ### `2`
 
 ```
-✔ No known problems!
-
-```
-
-### `2: formatted`
-
-```
-const foo = () => {
-	this;
-};
-
-```
-
-### `3`
-
-```
 
  unknown:1:12 lint/js/preferFunctionDeclarations FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -85,7 +69,7 @@ const foo = () => {
 
 ```
 
-### `3: formatted`
+### `2: formatted`
 
 ```
 function foo() {
@@ -93,6 +77,22 @@ function foo() {
 		this;
 	}
 }
+
+```
+
+### `3`
+
+```
+✔ No known problems!
+
+```
+
+### `3: formatted`
+
+```
+const foo = () => {
+	this;
+};
 
 ```
 

--- a/packages/@romejs/compiler/lint/rules/js/preferFunctionDeclarations.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/preferFunctionDeclarations.test.ts
@@ -11,47 +11,24 @@ import {testLint} from "../testHelpers";
 test(
 	"prefer function declarations",
 	async (t) => {
-		// Should complain on these
 		await testLint(
 			t,
-			"const foo = function () {};",
 			{
-				category: "lint/js/preferFunctionDeclarations",
+				invalid: [
+					"const foo = function () {};",
+					"const foo = () => {};",
+					// Doesn't need to be an arrow function because 'this' isn't from outer scope
+					"const foo = () => {function bar() {this;}};",
+				],
+				valid: [
+					// Allow arrow functions that use 'this' from outer scope
+					"const foo = () => {this;};",
+					// Allow functions with return types since you can't express that with a declaration
+					"const foo: string = function () {};",
+				],
 			},
-		);
-		await testLint(
-			t,
-			"const foo = () => {};",
 			{
 				category: "lint/js/preferFunctionDeclarations",
-			},
-		);
-
-		// Should allow arrow functions when they have this
-		await testLint(
-			t,
-			"const foo = () => {this;};",
-			{
-				category: "lint/js/preferFunctionDeclarations",
-			},
-		);
-
-		// But only if it refers to the actual arrow function
-		await testLint(
-			t,
-			"const foo = () => {function bar() {this;}};",
-			{
-				category: "lint/js/preferFunctionDeclarations",
-			},
-		);
-
-		// Should ignore functions with return types since you can't express that with a declaration
-		await testLint(
-			t,
-			"const foo: string = function () {};",
-			{
-				category: "lint/js/preferFunctionDeclarations",
-				syntax: ["ts"],
 			},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/preferTemplate.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/preferTemplate.test.ts
@@ -13,15 +13,12 @@ test(
 	async (t) => {
 		await testLint(
 			t,
-			`const foo = 'bar'; console.log(foo + 'baz')`,
 			{
-				category: "lint/js/preferTemplate",
+				invalid: [
+					`const foo = 'bar'; console.log(foo + 'baz')`,
+					`console.log((1 * 2) + 'baz')`,
+				],
 			},
-		);
-
-		await testLint(
-			t,
-			`console.log((1 * 2) + 'baz')`,
 			{
 				category: "lint/js/preferTemplate",
 			},

--- a/packages/@romejs/compiler/lint/rules/js/preferWhile.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/preferWhile.test.ts
@@ -6,26 +6,28 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 import {dedent} from "@romejs/string-utils";
 
 test(
 	"prefer while",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				dedent`
+			{
+				invalid: [
+					dedent`
           for (; x.running;) {
             x.step();
           }
         `,
-				dedent`
+					dedent`
           for (;;) {
             doSomething();
           }
         `,
-			],
+				],
+			},
 			{category: "lint/js/preferWhile"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/restrictedGlobals.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/restrictedGlobals.test.md
@@ -34,14 +34,12 @@ console.log(event);
 
 ```
 
- unknown:8:8 lint/js/restrictedGlobals ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:4 lint/js/restrictedGlobals ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Do not use the global variable event.
 
-    7 │     // invalid, event is used as a global.
-  > 8 │     foo(event)
-      │         ^^^^^
-    9 │     
+    foo(event)
+        ^^^^^
 
   ℹ Use a local variable instead.
 
@@ -54,12 +52,22 @@ console.log(event);
 ### `1: formatted`
 
 ```
-// valid use of event into the function scope.
+foo(event);
+
+```
+
+### `2`
+
+```
+✔ No known problems!
+
+```
+
+### `2: formatted`
+
+```
 function foo(event) {
 	console.info(event);
 }
-
-// invalid, event is used as a global.
-foo(event);
 
 ```

--- a/packages/@romejs/compiler/lint/rules/js/restrictedGlobals.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/restrictedGlobals.test.ts
@@ -7,30 +7,31 @@
 
 import {test} from "rome";
 import {testLint} from "../testHelpers";
+import {dedent} from "@romejs/string-utils";
 
 test(
 	"restricted globals",
 	async (t) => {
 		await testLint(
 			t,
-			"console.log(event);",
+			{
+				invalid: [
+					// invalid, event is used as a global.
+					"console.log(event);",
+					"foo(event)",
+				],
+				valid: [
+					// valid use of event into the function scope.
+					dedent`
+						function foo(event) {
+							console.info(event);
+						}
+					`,
+				],
+			},
 			{
 				category: "lint/js/restrictedGlobals",
 			},
-		);
-
-		await testLint(
-			t,
-			`
-    // valid use of event into the function scope.
-    function foo(event) {
-      console.info(event);
-    }
-
-    // invalid, event is used as a global.
-    foo(event)
-    `,
-			{category: "lint/js/restrictedGlobals"},
 		);
 	},
 );

--- a/packages/@romejs/compiler/lint/rules/js/singleVarDeclarator.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/singleVarDeclarator.test.ts
@@ -11,19 +11,15 @@ import {testLint} from "../testHelpers";
 test(
 	"enforce single var declarator",
 	async (t) => {
-		// Autofix
 		await testLint(
 			t,
-			`let foo, bar;`,
 			{
-				category: "lint/js/singleVarDeclarator",
+				invalid: ["let foo, bar;"],
+				valid: [
+					// Ignores loop heads
+					"for (let i = 0, x = 1; i < arr.length; i++) {}",
+				],
 			},
-		);
-
-		// Ignores loop heads
-		await testLint(
-			t,
-			`for (let i = 0, x = 1; i < arr.length; i++) {}`,
 			{
 				category: "lint/js/singleVarDeclarator",
 			},

--- a/packages/@romejs/compiler/lint/rules/js/sortImportExportSpecifiers.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/sortImportExportSpecifiers.test.ts
@@ -6,27 +6,29 @@
  */
 
 import {test} from "rome";
-import {testLintMultiple} from "../testHelpers";
+import {testLint} from "../testHelpers";
 
 test(
 	"enforce single var declarator",
 	async (t) => {
-		await testLintMultiple(
+		await testLint(
 			t,
-			[
-				// import statements
-				`import {b, a, c, D} from "mod";`,
-				`import {b as A, a as C, B} from "mod";`,
-				`import {c, b as b2, b as b1, b} from "mod";`,
-				// export external statements
-				`export {b, a, c, D} from "mod";`,
-				`export {b as A, a as C, B} from "mod";`,
-				`export {c, b as b2, b as b1, b} from "mod";`,
-				// export local statements
-				`export {b, a, c, D};`,
-				`export {b as A, a as C, B};`,
-				`export {c, b as b2, b as b1, b};`,
-			],
+			{
+				invalid: [
+					// import statements
+					`import {b, a, c, D} from "mod";`,
+					`import {b as A, a as C, B} from "mod";`,
+					`import {c, b as b2, b as b1, b} from "mod";`,
+					// export external statements
+					`export {b, a, c, D} from "mod";`,
+					`export {b as A, a as C, B} from "mod";`,
+					`export {c, b as b2, b as b1, b} from "mod";`,
+					// export local statements
+					`export {b, a, c, D};`,
+					`export {b as A, a as C, B};`,
+					`export {c, b as b2, b as b1, b};`,
+				],
+			},
 			{category: "lint/js/sortImportExportSpecifiers"},
 		);
 	},

--- a/packages/@romejs/compiler/lint/rules/js/sparseArray.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/sparseArray.test.ts
@@ -11,6 +11,6 @@ import {testLint} from "../testHelpers";
 test(
 	"sparse array",
 	async (t) => {
-		await testLint(t, `[1,,2]`, {category: "lint/js/sparseArray"});
+		await testLint(t, {invalid: ["[1,,2]"]}, {category: "lint/js/sparseArray"});
 	},
 );

--- a/packages/@romejs/compiler/lint/rules/js/undeclaredVariable.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/undeclaredVariable.test.ts
@@ -11,6 +11,10 @@ import {testLint} from "../testHelpers";
 test(
 	"undeclared variable",
 	async (t) => {
-		await testLint(t, "foobar;", {category: "lint/js/undeclaredVariables"});
+		await testLint(
+			t,
+			{invalid: ["foobar;"]},
+			{category: "lint/js/undeclaredVariables"},
+		);
 	},
 );

--- a/packages/@romejs/compiler/lint/rules/js/unsafeNegation.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/unsafeNegation.test.ts
@@ -11,6 +11,10 @@ import {testLint} from "../testHelpers";
 test(
 	"unsafe negation",
 	async (t) => {
-		await testLint(t, `!1 in [1,2]`, {category: "lint/js/unsafeNegation"});
+		await testLint(
+			t,
+			{invalid: ["!1 in [1,2]"]},
+			{category: "lint/js/unsafeNegation"},
+		);
 	},
 );


### PR DESCRIPTION
This is a quick pass through the rest of the existing lint/rules/js tests to convert them to use `TestLintInput`. I'll want to go through them again later to add some more test cases and look at everything more closely. I'll also work on tests for the rules that don't have them.

A few notes:

There are open issues for `noShadowRestrictedNames` and `noFunctionAssign` so the failing test cases are commented out.

 In the `noDeleteVars` snapshot, there are "No known problems" for 
```
const obj = {a: {b: {c: 123}}};
delete obj.a.b.c;
```
but the output is still reformatted as `obj.a.b.c = undefined;`

 The code frame recommended fixes don't look right in some of the snapshots, like in `sparseArray` and `negationElse`.