### PR TITLE
Fix noShadowRestrictedNames lint rule

### DIFF
--- a/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.md
@@ -86,3 +86,59 @@ try {
 }
 
 ```
+
+### `3`
+
+```
+
+ unknown:1:10 lint/js/noShadowRestrictedNames ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Do not shadow the global Array property.
+
+    !function Array() {}
+              ^^^^^
+
+  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named
+    after a known global.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `3: formatted`
+
+```
+!function Array() {};
+
+```
+
+### `4`
+
+```
+
+ unknown:1:14 lint/js/noShadowRestrictedNames ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ Do not shadow the global JSON property.
+
+    function test(JSON) {console.log(JSON)}
+                  ^^^^
+
+  ℹ Consider renaming this variable. It's easy to confuse the origin of variables when they're named
+    after a known global.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
+
+```
+
+### `4: formatted`
+
+```
+function test(JSON) {
+	console.log(JSON);
+}
+
+```

--- a/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.test.ts
@@ -18,9 +18,8 @@ test(
 					"function NaN() {}",
 					"let Set;",
 					"try {  } catch(Object) {}",
-					// These are false negatives
-					// "!function Array() {}",
-					// "function test(JSON) {console.log(JSON)}",
+					"!function Array() {}",
+					"function test(JSON) {console.log(JSON)}",
 				],
 			},
 			{category: "lint/js/noShadowRestrictedNames"},

--- a/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.ts
+++ b/packages/@romejs/compiler/lint/rules/js/noShadowRestrictedNames.ts
@@ -17,7 +17,7 @@ export default {
 	enter(path: Path): TransformExitResult {
 		const {node, context, scope} = path;
 
-		if (scope.node === node) {
+		if (scope.node === node || node.type === "JSFunctionHead") {
 			for (const [name, binding] of scope.getOwnBindings()) {
 				if (restrictedNames.has(name)) {
 					context.addNodeDiagnostic(


### PR DESCRIPTION
If it's intentional that `path.scope.node !== path.node` for `JSFunctionDeclaration` nodes, then this fixes a bug with the `noShadowRestrictedNames` lint rule.

If that's not intentional, then this is just a symptom of a different problem.

Closes #547 