### PR TITLE
add test cases for toCamelCase for forceCapitalization param

### DIFF
--- a/packages/@romejs/compiler/lint/rules/react/jsxPascalCase.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/jsxPascalCase.test.md
@@ -36,7 +36,7 @@
 
  unknown:1 lint/react/jsxPascalCase ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Switch FOO_COMPONENT to FOOCOMPONENT.
+  ✖ Switch FOO_COMPONENT to FooComponent.
 
     <FOO_COMPONENT />
     ^^^^^^^^^^^^^^^^^

--- a/packages/@romejs/string-utils/toCamelCase.test.ts
+++ b/packages/@romejs/string-utils/toCamelCase.test.ts
@@ -11,15 +11,22 @@ import {test} from "rome";
 test(
 	"toCamelCase",
 	(t) => {
-		const testCases = [
+		[
 			{input: "rometest", expected: "rometest"},
 			{input: "rome test", expected: "romeTest"},
 			{input: "RoMe TeSt", expected: "RoMeTeSt"},
-			{input: "ROME TEST", expected: "ROMETEST"},
-		];
-
-		testCases.forEach((td) => {
+			{input: "ROME TEST", expected: "RomeTest"},
+		].forEach((td) => {
 			t.is(toCamelCase(td.input), td.expected);
+		});
+
+		[
+			{input: "rometest", expected: "Rometest"},
+			{input: "rome test", expected: "RomeTest"},
+			{input: "RoMe TeSt", expected: "RoMeTeSt"},
+			{input: "ROME TEST", expected: "RomeTest"},
+		].forEach((td) => {
+			t.is(toCamelCase(td.input, true), td.expected);
 		});
 	},
 );

--- a/packages/@romejs/string-utils/toCamelCase.ts
+++ b/packages/@romejs/string-utils/toCamelCase.ts
@@ -11,8 +11,8 @@ export function toCamelCase(str: string, forceCapitalize?: boolean): string {
 		return str;
 	}
 
-	// Prepend uppercase letters with a space
-	str = str.replace(/([A-Z+])/g, " $1");
+	// Prepend uppercase letters with a space unless all characters are uppercase
+	str = str.toUpperCase() === str ? ` ${str}` : str.replace(/([A-Z+])/g, " $1");
 
 	// We no longer care about the casing
 	str = str.toLowerCase();


### PR DESCRIPTION
this is from conversations in : https://github.com/romejs/rome/pull/551#issuecomment-636415303

I have questions around some of the test cases:
```
{input: "RoMe TeSt", expected: "RoMeTeSt"},
{input: "ROME TEST", expected: "ROMETEST"},
```
Should these actually be?
```
{input: "RoMe TeSt", expected: "RomeTest"},  // this one I could see as staying RoMeTeSt
{input: "ROME TEST", expected: "RomeTest"},
```


What updated functionality would be good for toCamelCase? We could change the the second parameter to be an object of different options. @sebmck if you have specifics in mind, I can incorporate into this pr and apply updates.