### PR TITLE
Fix Event unsubscribe

### DIFF
--- a/packages/@romejs/events/Event.ts
+++ b/packages/@romejs/events/Event.ts
@@ -196,6 +196,7 @@ export default class Event<Param, Ret = void> {
 		// If this callback was the root subscription, then set it to the next one
 		if (callback === this.rootSubscription) {
 			this.rootSubscription = Array.from(this.subscriptions)[0];
+			this.subscriptions.delete(this.rootSubscription);
 			this.onSubscriptionChange();
 			return;
 		}


### PR DESCRIPTION
If an existing subscription becomes the `rootSubscription`, it needs to be removed from the `subscriptions` Set to avoid being invoked twice per message.