### PR TITLE
Fix Event clear and Bridge constructor

### DIFF
--- a/packages/@romejs/events/Bridge.ts
+++ b/packages/@romejs/events/Bridge.ts
@@ -69,7 +69,6 @@ export default class Bridge {
 			});
 		}
 
-		this.clear();
 		this.init();
 	}
 

--- a/packages/@romejs/events/Event.ts
+++ b/packages/@romejs/events/Event.ts
@@ -44,6 +44,7 @@ export default class Event<Param, Ret = void> {
 
 	clear() {
 		this.subscriptions.clear();
+		this.rootSubscription = undefined;
 	}
 
 	hasSubscribers(): boolean {


### PR DESCRIPTION
This fixes the Event#clear method so that it also removes the rootSubscription.

That revealed a problem with the Bridge constructor, which was calling `this.clear()` after creating and subscribing to the heartbeatEvent. Since Event#clear was ignoring the rootSubscription, clearing the heartbeatEvent had no effect prior to this change.

I don't think the call to `this.clear()` is currently doing anything in the constructor, so I just removed it. If it's intended as a hook or it's doing something I don't understand, please let me know and I'll put it back before the subscription.