### PR TITLE
Fix var binding to scope

### DIFF
--- a/packages/@romejs/compiler/scope/evaluators/JSVariableDeclaration.ts
+++ b/packages/@romejs/compiler/scope/evaluators/JSVariableDeclaration.ts
@@ -44,7 +44,7 @@ export default createScopeEvaluator({
 
 				if (
 					node.kind === "var" &&
-					(scope.kind === "program" || scope.kind === "function")
+					(scope.kind === "program" || scope.kind === "block")
 				) {
 					if (!scope.hasHoistedVars) {
 						throw new Error(

--- a/packages/@romejs/compiler/scope/evaluators/JSVariableDeclarationStatement.ts
+++ b/packages/@romejs/compiler/scope/evaluators/JSVariableDeclarationStatement.ts
@@ -18,7 +18,7 @@ export default createScopeEvaluator({
 			for (const {name} of getBindingIdentifiers(node)) {
 				scope.addGlobal(name);
 			}
-		} else {
+		} else if (node.declaration.kind !== "var") {
 			scope.injectEvaluate(node.declaration, node);
 		}
 	},


### PR DESCRIPTION
The recent scope-tracking improvements changed the kind of scope that `var` bindings are attached to. This fixes the `JSVariableDeclaration` evaluator so that it can add `var` bindings to the scope.

It also changes `JSVariableDeclarationStatement` so that it doesn't attempt to add `var` bindings, because that should be handled by `addVarBindings` on the relevant block. Without this change, `var` declarations inside a nested block scope would cause an error to be thrown.

Closes #574
Closes #535