### PR TITLE
Move deletedFileEvent call in handleDeletion

### DIFF
--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -392,7 +392,7 @@ export default class MemoryFileSystem {
 		listing.set(path, path);
 	}
 
-	handleDeletion(path: AbsoluteFilePath): void {
+	async handleDeletion(path: AbsoluteFilePath): Promise<void> {
 		// If a folder then evict all children
 		const folderInfo = this.directories.get(path);
 		if (folderInfo !== undefined) {
@@ -406,6 +406,9 @@ export default class MemoryFileSystem {
 				}
 			}
 		}
+
+		// Wait for any subscribers that might need the file's stats
+		await this.deletedFileEvent.call(path);
 
 		// Remove from 'all possible caches
 		this.files.delete(path);
@@ -422,8 +425,6 @@ export default class MemoryFileSystem {
 		if (parentListing !== undefined) {
 			parentListing.delete(path);
 		}
-
-		this.deletedFileEvent.send(path);
 	}
 
 	handleDeletedManifest(path: AbsoluteFilePath): void {

--- a/packages/@romejs/core/master/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/master/fs/MemoryFileSystem.ts
@@ -402,7 +402,7 @@ export default class MemoryFileSystem {
 			if (listing !== undefined) {
 				this.directoryListings.delete(path);
 				for (const path of listing.values()) {
-					this.handleDeletion(path);
+					await this.handleDeletion(path);
 				}
 			}
 		}


### PR DESCRIPTION
This changes MemoryFileSystem handleDeletion to call `deletedFileEvent` before deleting the `files` entry, so that subscribers don't throw an error when they try to get the file stats in response to the event.

I wasn't sure about the correct position for the event call relative to the other effects of the `handleDeletion` function. Does this look right?

This is related to #389 but doesn't close the issue because rome will still crash for a different reason.