### PR TITLE
fix: adjust cursor position by <inverse> tag padding

### DIFF
--- a/packages/@romejs/compiler/lint/rules/js/caseSingleStatement.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/caseSingleStatement.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:3:11 lint/js/caseSingleStatement FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:3:11 lint/js/caseSingleStatement  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ A switch case should only have a single statement. If you want more, then wrap it in a block.
 

--- a/packages/@romejs/compiler/lint/rules/js/confusingLanguage.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/confusingLanguage.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:5 lint/js/confusingLanguage FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:5 lint/js/confusingLanguage  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The word blacklist can be considered racially charged language.
 
@@ -36,7 +36,7 @@
 
 ```
 
- unknown:2 lint/js/confusingLanguage FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2 lint/js/confusingLanguage  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The word blacklist can be considered racially charged language.
 
@@ -66,7 +66,7 @@ blacklist	*/
 
 ```
 
- unknown:1 lint/js/confusingLanguage FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/confusingLanguage  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The word blacklist can be considered racially charged language.
 
@@ -94,7 +94,7 @@ blacklist;
 
 ```
 
- unknown:1 lint/js/confusingLanguage FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/confusingLanguage  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The word blacklist can be considered racially charged language.
 
@@ -122,7 +122,7 @@ BLACKLIST;
 
 ```
 
- unknown:1:4 lint/js/confusingLanguage FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:4 lint/js/confusingLanguage  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The word blacklist can be considered racially charged language.
 
@@ -150,7 +150,7 @@ someBlacklist;
 
 ```
 
- unknown:1:5 lint/js/confusingLanguage FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:5 lint/js/confusingLanguage  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The word blacklist can be considered racially charged language.
 

--- a/packages/@romejs/compiler/lint/rules/js/doubleEquals.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/doubleEquals.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/doubleEquals FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/doubleEquals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use === instead of ==.
 

--- a/packages/@romejs/compiler/lint/rules/js/duplicateImportSource.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/duplicateImportSource.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:2 lint/js/duplicateImportSource FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2 lint/js/duplicateImportSource  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ This module has already been imported.
 

--- a/packages/@romejs/compiler/lint/rules/js/negationElse.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/negationElse.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/negationElse FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/negationElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Invert blocks when performing a negation test.
 
@@ -44,7 +44,7 @@ if (true) {
 
 ```
 
- unknown:1 lint/js/negationElse FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/negationElse  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Invert blocks when performing a negation test.
 

--- a/packages/@romejs/compiler/lint/rules/js/noDebugger.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noDebugger.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/noDebugger FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/noDebugger  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ This is an unexpected use of the debugger statement.
 

--- a/packages/@romejs/compiler/lint/rules/js/noDelete.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noDelete.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:2 lint/js/noDelete FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2 lint/js/noDelete  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ This is an unexpected use of the delete operator.
 
@@ -39,7 +39,7 @@ arr[0][2] = undefined;
 
 ```
 
- unknown:2 lint/js/noDelete FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2 lint/js/noDelete  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ This is an unexpected use of the delete operator.
 

--- a/packages/@romejs/compiler/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noMultipleSpacesInRegularExpressionLiterals.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:4 lint/js/noMultipleSpacesInRegularExpressionLiterals FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:4 lint/js/noMultipleSpacesInRegularExpressionLiterals  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ This regular expression contains unclear uses of multiple spaces.
 

--- a/packages/@romejs/compiler/lint/rules/js/noShorthandArrayType.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noShorthandArrayType.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:2:13 lint/js/noShorthandArrayType FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2:13 lint/js/noShorthandArrayType  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use <emphasis>Array<T> syntax</emphasis> instead of <emphasis>shorthand T[] syntax</emphasis>.
 

--- a/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -40,7 +40,7 @@ if (x) {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -79,7 +79,7 @@ if (x) {
 
 ```
 
- unknown:3:7 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:3:7 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -115,7 +115,7 @@ if (x) {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -148,7 +148,7 @@ while (true) {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -181,7 +181,7 @@ for (p in obj) {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -214,7 +214,7 @@ for (x of xs) {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -247,7 +247,7 @@ do {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 
@@ -280,7 +280,7 @@ while (x) {
 
 ```
 
- unknown:1 lint/js/preferBlockStatements FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferBlockStatements  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Block statements are preferred in this position.
 

--- a/packages/@romejs/compiler/lint/rules/js/preferFunctionDeclarations.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferFunctionDeclarations.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:12 lint/js/preferFunctionDeclarations FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:12 lint/js/preferFunctionDeclarations  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use a function declaration instead of a const function.
 
@@ -32,7 +32,7 @@ function foo() {}
 
 ```
 
- unknown:1:12 lint/js/preferFunctionDeclarations FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:12 lint/js/preferFunctionDeclarations  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use a function declaration instead of a const function.
 
@@ -56,7 +56,7 @@ function foo() {}
 
 ```
 
- unknown:1:12 lint/js/preferFunctionDeclarations FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:12 lint/js/preferFunctionDeclarations  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use a function declaration instead of a const function.
 

--- a/packages/@romejs/compiler/lint/rules/js/preferTemplate.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferTemplate.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:31 lint/js/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:31 lint/js/preferTemplate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Template literals are preferred over string concatenation.
 
@@ -38,7 +38,7 @@ console.log(`${foo}baz`);
 
 ```
 
- unknown:1:12 lint/js/preferTemplate FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:12 lint/js/preferTemplate  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Template literals are preferred over string concatenation.
 

--- a/packages/@romejs/compiler/lint/rules/js/preferWhile.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferWhile.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/preferWhile FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferWhile  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use while loops instead of for loops.
 
@@ -44,7 +44,7 @@ while (x.running) {
 
 ```
 
- unknown:1 lint/js/preferWhile FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/preferWhile  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use while loops instead of for loops.
 

--- a/packages/@romejs/compiler/lint/rules/js/singleVarDeclarator.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/singleVarDeclarator.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/singleVarDeclarator FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/singleVarDeclarator  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Declare variables separately.
 

--- a/packages/@romejs/compiler/lint/rules/js/sortImportExportSpecifiers.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/sortImportExportSpecifiers.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the import declaration should be sorted alphabetically.
 
@@ -37,7 +37,7 @@ import {D, a, b, c} from "mod";
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the import declaration should be sorted alphabetically.
 
@@ -66,7 +66,7 @@ import {b as A, B, a as C} from "mod";
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the import declaration should be sorted alphabetically.
 
@@ -95,7 +95,7 @@ import {b, b as b1, b as b2, c} from "mod";
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the export declaration should be sorted alphabetically.
 
@@ -124,7 +124,7 @@ export {D, a, b, c} from "mod";
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the export declaration should be sorted alphabetically.
 
@@ -153,7 +153,7 @@ export {B, a as C, b as A} from "mod";
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the export declaration should be sorted alphabetically.
 
@@ -182,7 +182,7 @@ export {b, b as b1, b as b2, c} from "mod";
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the export declaration should be sorted alphabetically.
 
@@ -211,7 +211,7 @@ export {D, a, b, c};
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the export declaration should be sorted alphabetically.
 
@@ -240,7 +240,7 @@ export {B, a as C, b as A};
 
 ```
 
- unknown:1 lint/js/sortImportExportSpecifiers FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/sortImportExportSpecifiers  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The specifiers of the export declaration should be sorted alphabetically.
 

--- a/packages/@romejs/compiler/lint/rules/js/sparseArray.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/sparseArray.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:3 lint/js/sparseArray FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:3 lint/js/sparseArray  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ This array contains an empty slot.
 

--- a/packages/@romejs/compiler/lint/rules/js/unsafeNegation.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/unsafeNegation.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/js/unsafeNegation FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/js/unsafeNegation  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The negation operator is used unsafely on the left side of this binary expression.
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/ariaProps.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/ariaProps.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:20 lint/jsx-a11y/ariaProps FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:20 lint/jsx-a11y/ariaProps  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ aria-labell is an invalid ARIA attribute.
 
@@ -60,7 +60,7 @@
 
 ```
 
- unknown:1:5 lint/jsx-a11y/ariaProps FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:5 lint/jsx-a11y/ariaProps  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ aria-labeledby is an invalid ARIA attribute.
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noAccessKey.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noAccessKey.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:7 lint/jsx-a11y/noAccessKey FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:7 lint/jsx-a11y/noAccessKey  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid the accessKey attribute to reduce inconsistencies between keyboard shortcuts and screen
     reader keyboard comments.
@@ -41,7 +41,7 @@
 
 ```
 
- unknown:1:7 lint/jsx-a11y/noAccessKey FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:7 lint/jsx-a11y/noAccessKey  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid the accessKey attribute to reduce inconsistencies between keyboard shortcuts and screen
     reader keyboard comments.

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noAutofocus.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noAutofocus.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:7 lint/jsx-a11y/noAutofocus FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:7 lint/jsx-a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid the autoFocus attribute.
 
@@ -40,7 +40,7 @@
 
 ```
 
- unknown:1:7 lint/jsx-a11y/noAutofocus FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:7 lint/jsx-a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid the autoFocus attribute.
 
@@ -72,7 +72,7 @@
 
 ```
 
- unknown:1:7 lint/jsx-a11y/noAutofocus FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:7 lint/jsx-a11y/noAutofocus  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid the autoFocus attribute.
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noRedundantRoles.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noRedundantRoles.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:9 lint/jsx-a11y/noRedundantRoles FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:9 lint/jsx-a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using the role attribute article on the article element is redundant.
 
@@ -37,7 +37,7 @@
 
 ```
 
- unknown:1:8 lint/jsx-a11y/noRedundantRoles FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:8 lint/jsx-a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using the role attribute button on the button element is redundant.
 
@@ -66,7 +66,7 @@
 
 ```
 
- unknown:1:4 lint/jsx-a11y/noRedundantRoles FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:4 lint/jsx-a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using the role attribute heading on the h1 element is redundant.
 
@@ -95,7 +95,7 @@
 
 ```
 
- unknown:1:4 lint/jsx-a11y/noRedundantRoles FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:4 lint/jsx-a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using the role attribute heading on the h1 element is redundant.
 
@@ -124,7 +124,7 @@
 
 ```
 
- unknown:1:8 lint/jsx-a11y/noRedundantRoles FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:8 lint/jsx-a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using the role attribute dialog on the dialog element is redundant.
 
@@ -153,7 +153,7 @@
 
 ```
 
- unknown:1:24 lint/jsx-a11y/noRedundantRoles FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:24 lint/jsx-a11y/noRedundantRoles  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Using the role attribute checkbox on the input element is redundant.
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noTargetBlank.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noTargetBlank.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:31 lint/jsx-a11y/noTargetBlank FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:31 lint/jsx-a11y/noTargetBlank  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using target="_blank" without rel="noreferrer".
 
@@ -40,7 +40,7 @@
 
 ```
 
- unknown:1:22 lint/jsx-a11y/noTargetBlank FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:22 lint/jsx-a11y/noTargetBlank  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using target="_blank" without rel="noreferrer".
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/scope.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/scope.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/jsx-a11y/scope FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/jsx-a11y/scope  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using the scope attribute on elements other than th elements.
 
@@ -39,7 +39,7 @@
 
 ```
 
- unknown:1 lint/jsx-a11y/scope FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/jsx-a11y/scope  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using the scope attribute on elements other than th elements.
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/tabindexNoPositive.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/tabindexNoPositive.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:6 lint/jsx-a11y/tabindexNoPositive FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:6 lint/jsx-a11y/tabindexNoPositive  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid positive integer values for the tabIndex attribute.
 
@@ -40,7 +40,7 @@
 
 ```
 
- unknown:1:6 lint/jsx-a11y/tabindexNoPositive FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:6 lint/jsx-a11y/tabindexNoPositive  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid positive integer values for the tabIndex attribute.
 
@@ -72,7 +72,7 @@
 
 ```
 
- unknown:1:6 lint/jsx-a11y/tabindexNoPositive FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:6 lint/jsx-a11y/tabindexNoPositive  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid positive integer values for the tabIndex attribute.
 

--- a/packages/@romejs/compiler/lint/rules/react/jsxFragments.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/jsxFragments.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -38,7 +38,7 @@
 
 ```
 
- unknown:1 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -68,7 +68,7 @@
 
 ```
 
- unknown:1:19 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:19 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -98,7 +98,7 @@ const Hello = <div><Foo /><Foo /></div>;
 
 ```
 
- unknown:1:19 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:19 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -128,7 +128,7 @@ const Hello = <div><Foo /><Foo /></div>;
 
 ```
 
- unknown:1:14 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:14 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -158,7 +158,7 @@ const Hello = <><Foo /><Foo /></>;
 
 ```
 
- unknown:1:14 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:14 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -188,7 +188,7 @@ const Hello = <><Foo /><Foo /></>;
 
 ```
 
- unknown:3:16 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:3:16 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -224,7 +224,7 @@ function Foo() {
 
 ```
 
- unknown:3:16 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:3:16 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -260,7 +260,7 @@ function Foo() {
 
 ```
 
- unknown:3:13 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:3:13 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -295,7 +295,7 @@ function Hello() {
 
 ```
 
- unknown:2:13 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2:13 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -330,7 +330,7 @@ function Hello() {
 
 ```
 
- unknown:1:20 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:20 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 
@@ -362,7 +362,7 @@ function Hello() {
 
 ```
 
- unknown:1:20 lint/react/jsxFragments FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:20 lint/react/jsxFragments  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Use shorthand syntax for Fragment elements instead of standard syntax.
 

--- a/packages/@romejs/compiler/lint/rules/react/jsxNoCommentText.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/jsxNoCommentText.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1:15 lint/react/jsxNoCommentText FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:15 lint/react/jsxNoCommentText  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Wrap comments inside children within braces.
 
@@ -40,7 +40,7 @@ const a = <div>// comment</div>;
 
 ```
 
- unknown:1:15 lint/react/jsxNoCommentText FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:15 lint/react/jsxNoCommentText  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Wrap comments inside children within braces.
 
@@ -71,7 +71,7 @@ const a = <div>/* comment */</div>;
 
 ```
 
- unknown:1:15 lint/react/jsxNoCommentText FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:15 lint/react/jsxNoCommentText  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Wrap comments inside children within braces.
 

--- a/packages/@romejs/compiler/lint/rules/react/noUselessFragment.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/noUselessFragment.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/react/noUselessFragment FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
 
@@ -39,7 +39,7 @@
 
 ```
 
- unknown:1:3 lint/react/noUselessFragment FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:3 lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
 
@@ -70,7 +70,7 @@
 
 ```
 
- unknown:1 lint/react/noUselessFragment FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
 
@@ -101,7 +101,7 @@
 
 ```
 
- unknown lint/react/noUselessFragment FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
 
@@ -131,7 +131,7 @@ foo;
 
 ```
 
- unknown lint/react/noUselessFragment FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
 
@@ -161,7 +161,7 @@ foo;
 
 ```
 
- unknown:2:5 lint/react/noUselessFragment FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:2:5 lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
 

--- a/packages/@romejs/compiler/lint/rules/react/voidDomElementsNoChildren.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/voidDomElementsNoChildren.test.md
@@ -8,7 +8,7 @@
 
 ```
 
- unknown:1 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ br is a void element tag and must not have children.
 
@@ -37,7 +37,7 @@
 
 ```
 
- unknown:1 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have children.
 
@@ -65,7 +65,7 @@
 
 ```
 
- unknown:1 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ hr is a void element tag and must not have children.
 
@@ -93,7 +93,7 @@
 
 ```
 
- unknown:1 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ area is a void element tag and must not have dangerouslySetInnerHTML.
 
@@ -121,7 +121,7 @@
 
 ```
 
- unknown:1 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have children, or dangerouslySetInnerHTML.
 
@@ -149,7 +149,7 @@
 
 ```
 
- unknown:1:28 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:28 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have children.
 
@@ -177,7 +177,7 @@ React.createElement("img", {children: "child"});
 
 ```
 
- unknown:1:28 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:28 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have dangerouslySetInnerHTML.
 
@@ -205,7 +205,7 @@ React.createElement("img", {dangerouslySetInnerHTML: {__html: "child"}});
 
 ```
 
- unknown:1:20 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:20 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have children.
 
@@ -234,7 +234,7 @@ React.createElement("img", {}, "child");
 
 ```
 
- unknown:1:22 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:22 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have children.
 
@@ -262,7 +262,7 @@ createElement("img", {children: "child"});
 
 ```
 
- unknown:1:22 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:22 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have dangerouslySetInnerHTML.
 
@@ -290,7 +290,7 @@ createElement("img", {dangerouslySetInnerHTML: {__html: "child"}});
 
 ```
 
- unknown:1:14 lint/react/voidDomElementsNoChildren FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1:14 lint/react/voidDomElementsNoChildren  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ img is a void element tag and must not have children.
 

--- a/packages/@romejs/core/master/commands/lint.test.md
+++ b/packages/@romejs/core/master/commands/lint.test.md
@@ -15,7 +15,7 @@
     unknownVariable
     ^^^^^^^^^^^^^^^
 
- project/index.js lint/pendingFixes FIXABLE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ project/index.js lint/pendingFixes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Pending formatting and recommended autofixes
 
@@ -56,7 +56,7 @@ unknownVariable
 
 ```
 
- project/index.js:1:4 lint/js/undeclaredVariables OUTDATED ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ project/index.js:1:4 lint/js/undeclaredVariables  OUTDATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The unformatted variable is undeclared.
 
@@ -67,7 +67,7 @@ unknownVariable
 
   ⚠ This file has been changed since the diagnostic was produced and may be out of date
 
- project/index.js:2:1 lint/js/undeclaredVariables OUTDATED ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ project/index.js:2:1 lint/js/undeclaredVariables  OUTDATED  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The swag variable is undeclared.
 

--- a/packages/@romejs/string-markup/Grid.ts
+++ b/packages/@romejs/string-markup/Grid.ts
@@ -758,8 +758,7 @@ export default class Grid {
 		}
 
 		if (hasText) {
-			// Wrap hr text in spaces
-			if (tag.name === "hr") {
+			if (tag.name === "hr" || tag.name === "inverse") {
 				return [
 					{
 						...tag,
@@ -910,7 +909,7 @@ function ansiFormatText(
 		}
 
 		case "inverse":
-			return formatAnsi.inverse(` ${value} `);
+			return formatAnsi.inverse(value);
 
 		case "emphasis":
 			return formatAnsi.bold(value);


### PR DESCRIPTION
`<hr>` trailing separator has incorrect width if `inverse` tag is present. This happens because padding is added at the formatting phase so the cursor position is not adjusted accordingly.

Before:

<img width="834" alt="Screenshot 2020-06-10 at 23 18 48" src="https://user-images.githubusercontent.com/1537724/84320080-60afa780-ab71-11ea-9eed-8f08393330bb.png">

After:

<img width="835" alt="Screenshot 2020-06-10 at 23 18 56" src="https://user-images.githubusercontent.com/1537724/84320120-6c9b6980-ab71-11ea-87ba-fb67f7ac7368.png">
