### PR TITLE
Fix file deletion handling during lint

### DIFF
--- a/packages/@romejs/core/server/WorkerManager.ts
+++ b/packages/@romejs/core/server/WorkerManager.ts
@@ -313,11 +313,7 @@ export default class WorkerManager {
 			// Give memoryFs a chance to finish initializing if it's in a pending project
 			await this.server.memoryFs.waitIfInitializingWatch(path);
 
-			stats = memoryFs.getFileStats(path);
-			if (stats === undefined) {
-				console.error(Array.from(memoryFs.files.keys(), (path) => path.join()));
-				throw new Error(`The file ${path.join()} doesn't exist`);
-			}
+			stats = memoryFs.getFileStatsAssert(path);
 		}
 
 		// Verify that this file doesn't exceed any size limit

--- a/packages/@romejs/core/server/dependencies/DependencyGraph.ts
+++ b/packages/@romejs/core/server/dependencies/DependencyGraph.ts
@@ -295,15 +295,17 @@ export default class DependencyGraph {
 			analyzeProgress.pushText(progressText);
 		}
 
-		const res: WorkerAnalyzeDependencyResult = await this.request.requestWorkerAnalyzeDependencies(
-			path,
-			{},
-		);
+		let res: WorkerAnalyzeDependencyResult;
+		let node: DependencyNode;
+		try {
+			res = await this.request.requestWorkerAnalyzeDependencies(path, {});
 
-		const node = this.addNode(path, res);
-		node.setAll(all);
-		node.setUsedAsync(async);
-		lock.release();
+			node = this.addNode(path, res);
+			node.setAll(all);
+			node.setUsedAsync(async);
+		} finally {
+			lock.release();
+		}
 
 		const {dependencies, diagnostics} = res;
 

--- a/packages/@romejs/core/server/fs/FileAllocator.ts
+++ b/packages/@romejs/core/server/fs/FileAllocator.ts
@@ -172,20 +172,21 @@ export default class FileAllocator {
 			lock.release();
 			return this.getOwnerAssert(path);
 		}
+		try {
+			const worker = await workerManager.getNextWorker(path);
 
-		const worker = await workerManager.getNextWorker(path);
+			// Add ourselves to the file map
+			logger.info(
+				`[FileAllocator] File %s assigned to worker %s`,
+				path.toMarkup(),
+				worker.id,
+			);
+			this.fileToWorker.set(filename, worker.id);
 
-		// Add ourselves to the file map
-		logger.info(
-			`[FileAllocator] File %s assigned to worker %s`,
-			path.toMarkup(),
-			worker.id,
-		);
-		this.fileToWorker.set(filename, worker.id);
-
-		// Release and continue
-		lock.release();
-
-		return worker;
+			return worker;
+		} finally {
+			// Release and continue
+			lock.release();
+		}
 	}
 }

--- a/packages/@romejs/core/server/linter/Linter.ts
+++ b/packages/@romejs/core/server/linter/Linter.ts
@@ -245,7 +245,7 @@ class LintRunner {
 		});
 
 		for (const path of evictedPaths) {
-			await queue.pushQueue(path);
+			await FileNotFound.allowMissing(path, () => queue.pushQueue(path));
 		}
 
 		await queue.spin();
@@ -299,9 +299,12 @@ class LintRunner {
 
 		// Build a list of dependents to recheck
 		for (const path of evictedPaths) {
-			validatedDependencyPaths.add(path);
+			const newNode = graph.maybeGetNode(path);
 
-			const newNode = graph.getNode(path);
+			if (newNode === undefined) {
+				continue;
+			}
+			validatedDependencyPaths.add(path);
 
 			// Get the previous node and see if the exports have actually changed
 			const oldNode = oldEvictedNodes.get(path);


### PR DESCRIPTION
This addresses some issues that were still causing crashes when files were deleted during a lint.

It adds handling for `FileNotFound` when `LintRunner` pushes paths onto the worker queue. It also adds a couple `try-finally` blocks to make sure that locks get released after a `FileNotFound` error is thrown.

Otherwise, deleted files would cause Rome to freeze when the `onChanges` handler is called for those deleted `evictedPaths`.

I removed the `console.error` from `WorkerManager#getNextWorker` so that I could use `getFileStatsAssert` to throw the `FileNotFound` error, but I can put it back if it’s still useful.