### PR TITLE
Disable callSync and callOptional for BridgeEvent

### DIFF
--- a/packages/@romejs/events/Bridge.test.ts
+++ b/packages/@romejs/events/Bridge.test.ts
@@ -111,6 +111,16 @@ test(
 			// client bridges can't call server<-client events
 			await barGreet.call("bar");
 		});
+
+		t.throws(() => {
+			// callSync not allowed on BridgeEvents
+			fooGreet.callSync();
+		});
+
+		t.throwsAsync(async () => {
+			// callOptional not allowed on BridgeEvents
+			fooGreet.callOptional();
+		});
 	},
 );
 

--- a/packages/@romejs/events/BridgeEvent.ts
+++ b/packages/@romejs/events/BridgeEvent.ts
@@ -210,4 +210,12 @@ export default class BridgeEvent<
 			throw err;
 		}
 	}
+
+	callSync(): never {
+		throw new Error(`callSync not allowed on BridgeEvent ${this.name}`);
+	}
+
+	callOptional(): never {
+		throw new Error(`callOptional not allowed on BridgeEvent ${this.name}`);
+	}
 }


### PR DESCRIPTION
These methods are inherited from the Event class, but they shouldn't be used on a BridgeEvent.