### PR TITLE
[MemoryFileSystem] Hijack mtime for set buffers 

### DIFF
--- a/packages/@romejs/core/server/ServerRequest.ts
+++ b/packages/@romejs/core/server/ServerRequest.ts
@@ -901,9 +901,12 @@ export default class ServerRequest {
 		await this.wrapRequestDiagnostic(
 			"updateBuffer",
 			path,
-			(bridge, file) => bridge.updateBuffer.call({file, content}),
+			async (bridge, file) => {
+				await bridge.updateBuffer.call({file, content});
+				this.server.memoryFs.addBuffer(path, content);
+				this.server.refreshFileEvent.send(path);
+			},
 		);
-		this.server.refreshFileEvent.send(path);
 	}
 
 	async requestWorkerClearBuffer(path: AbsoluteFilePath): Promise<void> {
@@ -912,10 +915,12 @@ export default class ServerRequest {
 		await this.wrapRequestDiagnostic(
 			"updateBuffer",
 			path,
-			(bridge, file) => bridge.clearBuffer.call({file}),
+			async (bridge, file) => {
+				await bridge.clearBuffer.call({file});
+				this.server.memoryFs.clearBuffer(path);
+				this.server.refreshFileEvent.send(path);
+			},
 		);
-		await this.server.fileAllocator.evict(path);
-		this.server.refreshFileEvent.send(path);
 	}
 
 	async requestWorkerParse(


### PR DESCRIPTION
In the LSP when there is a document change we notify workers of the new "file contents" that is used instead of getting it from disk. This works great, except that we'd hit the cache before we even get there and since the mtime matched what was in the cache then we would never update until there was an actual file save.

Well this fixes that!