### PR TITLE
fix: update docs with note about RJSON

### DIFF
--- a/website/src/_includes/docs/Getting started.md
+++ b/website/src/_includes/docs/Getting started.md
@@ -14,7 +14,7 @@ Now, create a Rome configuration for your project. When prompted, it is advised 
 rome init
 ```
 
-This command creates a Rome configuration file, `rome.json`, which looks like this:
+This command creates a Rome configuration file, `rome.rjson`, which looks like this:
 
 ```json
 {
@@ -24,5 +24,7 @@ This command creates a Rome configuration file, `rome.json`, which looks like th
   }
 }
 ```
+
+> Note: RJSON is a superset of JSON that supports more-concise syntax and features such as comments.
 
 You're all set to get started with Rome. Continue reading to explore the variety of commands that Rome supports.

--- a/website/src/styles/_content.scss
+++ b/website/src/styles/_content.scss
@@ -36,4 +36,14 @@
     padding: $unit / 4 0;
   }
 
+  blockquote {
+    border-left: $unit * 0.5 solid var(--blockquote-color);
+    margin: $unit 0 $unit * 1.5 0;
+    padding: $unit;
+
+    > p {
+      margin: 0;
+    }
+  }
+
 }

--- a/website/src/styles/_variables.scss
+++ b/website/src/styles/_variables.scss
@@ -27,6 +27,7 @@ $gray-8: lighten(#27272A, 80%);
   --pattern-img-path: url("/static/img/pattern-white.png");
   --toc-background-active: #{$gray-8};
   --toc-link-color-active: #{$gray-4};
+  --blockquote-color: #{$gray-7};
 
 }
 
@@ -42,6 +43,7 @@ html[data-theme='dark'] {
   --pattern-img-path: url("/static/img/pattern-black.png");
   --toc-background-active: #{$gray-3};
   --toc-link-color-active: #{$gray-8};
+  --blockquote-color: #{$gray-7};
 
 }
 


### PR DESCRIPTION
This pull request updates the new documentation site with a quick note about RJSON vs JSON and adds initial `blockquote` styling.

Replaces #602