### PR TITLE
fix: disallow non-numeric computed enum values

### DIFF
--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -18,6 +18,7 @@ export type DiagnosticCategory =
 	| "compile/classes"
 	| "compile/const-enums"
 	| "compile/jsx"
+	| "compile/nonnumeric-enum-values"
 	| "flags/invalid"
 	| "format/disabled"
 	| "internalError/httpServer"

--- a/packages/@romejs/diagnostics/descriptions/compiler.ts
+++ b/packages/@romejs/diagnostics/descriptions/compiler.ts
@@ -14,4 +14,8 @@ export const compiler = createDiagnosticsCategory({
 		category: "compile/const-enums",
 		message: "Const enums are not supported",
 	},
+	ENUM_COMPUTED_VALUES_UNSUPPORTED: {
+		category: "compile/nonnumeric-enum-values",
+		message: "Only numeric enums can have computed members",
+	},
 });


### PR DESCRIPTION
This pull request updates the TypeScript enum transform to more-closely match TypeScript compiler pragmatics. Specifically, initializers that resolve to values other than numbers that also use variable references are now considered errors.

Resolves #572

The following cases now fail:

```ts
const str = "str";
const bool = true;

enum Test1 {a = str}

enum Test2 {a = bool}
```