### PR TITLE
Fix mode switch text when themeInStorage === 'dark'

### DIFF
--- a/website/static/js/index.js
+++ b/website/static/js/index.js
@@ -160,9 +160,14 @@ const themeInStorage = window.localStorage.getItem('data-theme');
 
 if(!themeInStorage){
   window.localStorage.setItem('data-theme', 'light');
+} else {
+  const $doc = document.documentElement;
+  if (themeInStorage === "dark") {
+    elements.modeSwitch.innerText = "Light Mode";
+  }
 }
 
-document.documentElement.setAttribute('data-theme', window.localStorage.getItem('data-theme'));
+document.documentElement.setAttribute("data-theme", themeInStorage);
 
 //remove permalinkSymbol "#" from table of contents
 elements.tocLinks.forEach(function(link){


### PR DESCRIPTION
If the user has switched the docs to dark mode and refreshes the page, the text still shows "Dark Mode" when the page is refreshed:
![Kapture 2020-06-18 at 16 28 01](https://user-images.githubusercontent.com/11270438/85013847-e55a8100-b182-11ea-851c-4e6b2fa93976.gif)
