### PR TITLE
Add Locker wrapLock method

### DIFF
--- a/packages/@romejs/core/common/utils/Locker.test.ts
+++ b/packages/@romejs/core/common/utils/Locker.test.ts
@@ -85,3 +85,78 @@ test(
 		t.false(locker.hasLock("rome"));
 	},
 );
+
+test(
+	"Locker#wrapLock",
+	async (t) => {
+		const locker = new Locker<string>();
+		const lock = locker.getNewLock("rome");
+
+		let foo = "one";
+
+		async function bar() {
+			foo = "two";
+			// creates a lock internally and releases it after running a callback
+			await locker.wrapLock(
+				"rome",
+				() => {
+					foo = "three";
+				},
+			);
+		}
+
+		t.is(foo, "one");
+
+		bar();
+
+		t.is(foo, "two");
+
+		// wrapLock callback can execute now
+		lock.release();
+
+		// wait here for wrapLock to release its internal lock
+		await locker.waitLock("rome");
+
+		t.is(foo, "three");
+
+		t.false(locker.hasLock("rome"));
+	},
+);
+
+test(
+	"Locker#wrapLock throws",
+	async (t) => {
+		const locker = new Locker<string>();
+		const lock = locker.getNewLock("rome");
+
+		let foo = "one";
+
+		async function bar() {
+			foo = "two";
+			// creates a lock internally and releases it after running a callback
+			await locker.wrapLock(
+				"rome",
+				async () => {
+					foo = "three";
+					throw new Error("oops!");
+				},
+			);
+		}
+
+		t.is(foo, "one");
+
+		// bar throws an error but wrapLock still releases its internal lock
+		t.throwsAsync(async () => {
+			await bar();
+		});
+
+		t.is(foo, "two");
+
+		lock.release();
+		await locker.waitLock("rome");
+
+		t.is(foo, "three");
+
+		t.false(locker.hasLock("rome"));
+	},
+);

--- a/packages/@romejs/core/common/utils/Locker.test.ts
+++ b/packages/@romejs/core/common/utils/Locker.test.ts
@@ -93,14 +93,16 @@ test(
 		const lock = locker.getNewLock("rome");
 
 		let foo = "one";
+		let res = "";
 
 		async function bar() {
 			foo = "two";
 			// creates a lock internally and releases it after running a callback
-			await locker.wrapLock(
+			res = await locker.wrapLock(
 				"rome",
 				() => {
 					foo = "three";
+					return "result";
 				},
 			);
 		}
@@ -118,6 +120,8 @@ test(
 		await locker.waitLock("rome");
 
 		t.is(foo, "three");
+
+		t.is(res, "result");
 
 		t.false(locker.hasLock("rome"));
 	},

--- a/packages/@romejs/core/common/utils/Locker.ts
+++ b/packages/@romejs/core/common/utils/Locker.ts
@@ -76,4 +76,13 @@ export default class Locker<Key> {
 			lock.release();
 		}
 	}
+
+	async wrapLock(key: Key, callback: () => void | Promise<void>): Promise<void> {
+		const lock = await this.getLock(key);
+		try {
+			await callback();
+		} finally {
+			lock.release();
+		}
+	}
 }

--- a/packages/@romejs/core/common/utils/Locker.ts
+++ b/packages/@romejs/core/common/utils/Locker.ts
@@ -77,10 +77,10 @@ export default class Locker<Key> {
 		}
 	}
 
-	async wrapLock(key: Key, callback: () => void | Promise<void>): Promise<void> {
+	async wrapLock<T>(key: Key, callback: () => T | Promise<T>): Promise<T> {
 		const lock = await this.getLock(key);
 		try {
-			await callback();
+			return await callback();
 		} finally {
 			lock.release();
 		}


### PR DESCRIPTION
This adds a Locker method that wraps a callback in a lock that is automatically released even if the callback throws an error.