### PR TITLE
Inherit NodeJS.ErrnoException props in better node errors

### DIFF
--- a/packages/@romejs/node/errors.ts
+++ b/packages/@romejs/node/errors.ts
@@ -3,6 +3,11 @@ import {ERROR_FRAMES_PROP, ErrorWithFrames} from "@romejs/v8";
 function changeMessage(old: ErrorWithFrames, msg: string): Error {
 	const err: ErrorWithFrames = new Error(msg);
 
+	// Inherit some NodeJS.ErrnoException props
+	err.code = old.code;
+	err.path = old.path;
+	err.syscall = old.syscall;
+
 	// Without doing something jank we can't retain the original Error constructor ie. TypeError etc
 	// We probably don't need to or actually care
 	err.name = old.name;

--- a/packages/@romejs/v8/errors.ts
+++ b/packages/@romejs/v8/errors.ts
@@ -15,7 +15,7 @@ export * from "./types";
 
 export const ERROR_FRAMES_PROP = "ERROR_FRAMES";
 
-export type ErrorWithFrames = Error & {
+export type ErrorWithFrames = NodeJS.ErrnoException & {
 	[ERROR_FRAMES_PROP]?: unknown;
 };
 


### PR DESCRIPTION
Where we would previously emit `FileNotFound`, the `code` would not be present and so it would just be thrown as a regular error.