### PR TITLE
Remove romeLSPBin field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@types/vscode": "^1.46.0",
     "typescript": "^4.0.0-beta"
   },
-  "romeLSPBin": "./scripts/vendor-rome",
   "scripts": {
     "dev-rome": "node ./scripts/dev-rome",
     "test": "node ./scripts/dev-rome test",


### PR DESCRIPTION
Removing this field so that the VS Code extension uses `dev-rome` instead of `vendor-rome`. The extension will still look for rome in `node_modules` before looking for the dev folder.

This field can still be added locally to `package.json` to force the extension to use a different path for the rome LSPServer.