### PR TITLE
Add ability to output HTML for homepage screenshot

### DIFF
--- a/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
+++ b/packages/@romejs/cli-diagnostics/DiagnosticsPrinter.ts
@@ -608,14 +608,9 @@ export default class DiagnosticsPrinter extends Error {
 
 					const pallete = banner.palettes[palleteIndex];
 					stream.write(
-						formatAnsi.bgRgb(
-							" ",
-							{
-								r: pallete[0],
-								g: pallete[1],
-								b: pallete[2],
-							},
-						).repeat(times),
+						formatAnsi.bgRgb(" ", [pallete[0], pallete[1], pallete[2]]).repeat(
+							times,
+						),
 					);
 				}
 				stream.write("\n");

--- a/packages/@romejs/cli-diagnostics/highlightCode.ts
+++ b/packages/@romejs/cli-diagnostics/highlightCode.ts
@@ -88,7 +88,7 @@ function reduce<Token extends {
 }
 
 function invalidHighlight(line: string): string {
-	return markupTag("emphasis", markupTag("token", line, {bg: "red"}));
+	return markupTag("emphasis", markupTag("color", line, {bg: "red"}));
 }
 
 function highlightJSON(path: UnknownFilePath, input: string): string {

--- a/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.md
@@ -38,10 +38,10 @@
     
       at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68896:9) generated source location
+    s:68892:9) generated source location
       at StringMarkupParser.unexpected
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:73089:10) generated source location
+    s:73085:10) generated source location
       at StringMarkupParser.parseTag
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
     s:3265:18) generated source location
@@ -110,21 +110,21 @@
     s:68496:8) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68841:10) generated source location
+    s:68837:10) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68853:2) generated source location
+    s:68849:2) generated source location
       at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107377:3) generated source location
+    s:107373:3) generated source location
       at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
     location
       at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107285:3) generated source location
+    s:107281:3) generated source location
       at <anonymous>
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107394:3) generated source location
+    s:107390:3) generated source location
 
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -175,10 +175,10 @@ function hello(a, a) {
     
       at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68896:9) generated source location
+    s:68892:9) generated source location
       at StringMarkupParser.unexpected
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:73089:10) generated source location
+    s:73085:10) generated source location
       at StringMarkupParser.parseTag
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
     s:3265:18) generated source location
@@ -247,21 +247,21 @@ function hello(a, a) {
     s:68496:8) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68841:10) generated source location
+    s:68837:10) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68853:2) generated source location
+    s:68849:2) generated source location
       at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107377:3) generated source location
+    s:107373:3) generated source location
       at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
     location
       at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107285:3) generated source location
+    s:107281:3) generated source location
       at <anonymous>
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107394:3) generated source location
+    s:107390:3) generated source location
       at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
       at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
     (project-rome/@romejs/diagnostics/wrap.ts:28:16)
@@ -317,10 +317,10 @@ function hello(a, a) {
     
       at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68896:9) generated source location
+    s:68892:9) generated source location
       at StringMarkupParser.unexpected
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:73089:10) generated source location
+    s:73085:10) generated source location
       at StringMarkupParser.parseTag
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
     s:3265:18) generated source location
@@ -389,21 +389,21 @@ function hello(a, a) {
     s:68496:8) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68841:10) generated source location
+    s:68837:10) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68853:2) generated source location
+    s:68849:2) generated source location
       at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107377:3) generated source location
+    s:107373:3) generated source location
       at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
     location
       at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107285:3) generated source location
+    s:107281:3) generated source location
       at <anonymous>
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107394:3) generated source location
+    s:107390:3) generated source location
       at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
       at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
     (project-rome/@romejs/diagnostics/wrap.ts:28:16)

--- a/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.md
@@ -12,123 +12,14 @@
 
   ✖ Avoid duplicate function arguments. Check the a argument.
 
-  ✖ Encountered an error displaying this diagnostic
-  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
-    <emphasis>token</emphasis>
-    
-     unknown parse/stringMarkup
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
-      ✖ bg is not a valid attribute name for token
-    
-        2 │ <pad align="right" width="6"><emphasis> │ </emphasis></pad>                 
-    <error><emphasis>^</emphasis></error>
-        3 │ <pad align="right" width="6"><emphasis>  2 │ </emphasis></pad> <token
-    type="comment">//</token>
-      > 4 │ <pad align="right" width="6"><emphasis>  3 │ </emphasis></pad><token
-    type="punctuation">}</token><emphasis><token bg="red">a</token></emphasis></nobr>
-          │                                                                                         
-                            
-    ^
-    
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    ━━━
-    
-    ✖ Found 1 problem
-    
-      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68892:9) generated source location
-      at StringMarkupParser.unexpected
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:73085:10) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3265:18) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parse
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3418:24) generated source location
-      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3432:6) generated source location
-      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:49437:3) generated source location
-      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:49459:9) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52453:12) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52483:24) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52468:9) generated source location
-      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:56491:11) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:56194:11) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68656:17) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52188:3) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68650:12) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68521:30) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68502:4) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68521:9) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68496:8) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68837:10) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68849:2) generated source location
-      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107373:3) generated source location
-      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
-    location
-      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107281:3) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107390:3) generated source location
+  > 1 │ function hello(a, a) {
+      │                   ^
+    2 │  //
+    3 │ }a
 
-  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Found 1 problem
+✖ Found 1 problem
 
 ```
 
@@ -149,128 +40,14 @@ function hello(a, a) {
 
   ✖ Avoid duplicate function arguments. Check the a argument.
 
-  ✖ Encountered an error displaying this diagnostic
-  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
-    <emphasis>token</emphasis>
-    
-     unknown parse/stringMarkup
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
-      ✖ bg is not a valid attribute name for token
-    
-        2 │ <pad align="right" width="6"><emphasis> │ </emphasis></pad>                 
-    <error><emphasis>^</emphasis></error>
-        3 │ <pad align="right" width="6"><emphasis>  2 │ </emphasis></pad> <token
-    type="comment">//</token>
-      > 4 │ <pad align="right" width="6"><emphasis>  3 │ </emphasis></pad><token
-    type="punctuation">}</token><emphasis><token bg="red">a</token></emphasis></nobr>
-          │                                                                                         
-                            
-    ^
-    
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    ━━━
-    
-    ✖ Found 1 problem
-    
-      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68892:9) generated source location
-      at StringMarkupParser.unexpected
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:73085:10) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3265:18) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parse
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3418:24) generated source location
-      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3432:6) generated source location
-      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:49437:3) generated source location
-      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:49459:9) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52453:12) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52483:24) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52468:9) generated source location
-      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:56491:11) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:56194:11) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68656:17) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52188:3) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68650:12) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68521:30) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68502:4) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68521:9) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68496:8) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68837:10) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68849:2) generated source location
-      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107373:3) generated source location
-      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
-    location
-      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107281:3) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107390:3) generated source location
-      at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
-      at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
-    (project-rome/@romejs/diagnostics/wrap.ts:28:16)
-      at ___R$project$rome$$romejs$core$test$worker$TestWorkerRunner_ts$default.runTest
-    (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:494:25)
+  > 1 │ const hello = (a, a) => {
+      │                   ^
+    2 │  //
+    3 │ }a
 
-  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Found 1 problem
+✖ Found 1 problem
 
 ```
 
@@ -291,128 +68,14 @@ function hello(a, a) {
 
   ✖ Avoid duplicate function arguments. Check the a argument.
 
-  ✖ Encountered an error displaying this diagnostic
-  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
-    <emphasis>token</emphasis>
-    
-     unknown parse/stringMarkup
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
-      ✖ bg is not a valid attribute name for token
-    
-        2 │ <pad align="right" width="6"><emphasis> │ </emphasis></pad>                          
-    <error><emphasis>^</emphasis></error>
-        3 │ <pad align="right" width="6"><emphasis>  2 │ </emphasis></pad> <token
-    type="comment">//</token>
-      > 4 │ <pad align="right" width="6"><emphasis>  3 │ </emphasis></pad><token
-    type="punctuation">}</token><emphasis><token bg="red">a</token></emphasis></nobr>
-          │                                                                                         
-                            
-    ^
-    
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    ━━━
-    
-    ✖ Found 1 problem
-    
-      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68892:9) generated source location
-      at StringMarkupParser.unexpected
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:73085:10) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3265:18) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3407:17) generated source location
-      at StringMarkupParser.parse
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3418:24) generated source location
-      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:3432:6) generated source location
-      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:49437:3) generated source location
-      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:49459:9) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52453:12) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52483:24) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52468:9) generated source location
-      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:56491:11) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:56194:11) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68656:17) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:52188:3) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68650:12) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68521:30) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68502:4) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68521:9) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68496:8) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68837:10) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:68849:2) generated source location
-      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107373:3) generated source location
-      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
-    location
-      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107281:3) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
-    s:107390:3) generated source location
-      at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
-      at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
-    (project-rome/@romejs/diagnostics/wrap.ts:28:16)
-      at ___R$project$rome$$romejs$core$test$worker$TestWorkerRunner_ts$default.runTest
-    (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:494:25)
+  > 1 │ const hello = function (a, a) {
+      │                            ^
+    2 │  //
+    3 │ }a
 
-  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Found 1 problem
+✖ Found 1 problem
 
 ```
 

--- a/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.md
@@ -12,14 +12,123 @@
 
   ✖ Avoid duplicate function arguments. Check the a argument.
 
-  > 1 │ function hello(a, a) {
-      │                   ^
-    2 │  //
-    3 │ }a
+  ✖ Encountered an error displaying this diagnostic
+  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
+    <emphasis>token</emphasis>
+    
+     unknown parse/stringMarkup
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    
+      ✖ bg is not a valid attribute name for token
+    
+        2 │ <pad align="right" width="6"><emphasis> │ </emphasis></pad>                 
+    <error><emphasis>^</emphasis></error>
+        3 │ <pad align="right" width="6"><emphasis>  2 │ </emphasis></pad> <token
+    type="comment">//</token>
+      > 4 │ <pad align="right" width="6"><emphasis>  3 │ </emphasis></pad><token
+    type="punctuation">}</token><emphasis><token bg="red">a</token></emphasis></nobr>
+          │                                                                                         
+                            
+    ^
+    
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ━━━
+    
+    ✖ Found 1 problem
+    
+      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68896:9) generated source location
+      at StringMarkupParser.unexpected
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:73089:10) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3265:18) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parse
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3418:24) generated source location
+      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3432:6) generated source location
+      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:49437:3) generated source location
+      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:49459:9) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52453:12) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52483:24) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52468:9) generated source location
+      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:56491:11) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:56194:11) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68656:17) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52188:3) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68650:12) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68521:30) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68502:4) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68521:9) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68496:8) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68841:10) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68853:2) generated source location
+      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107377:3) generated source location
+      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
+    location
+      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107285:3) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107394:3) generated source location
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-✖ Found 1 problem
+  ✖ Found 1 problem
 
 ```
 
@@ -40,14 +149,128 @@ function hello(a, a) {
 
   ✖ Avoid duplicate function arguments. Check the a argument.
 
-  > 1 │ const hello = (a, a) => {
-      │                   ^
-    2 │  //
-    3 │ }a
+  ✖ Encountered an error displaying this diagnostic
+  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
+    <emphasis>token</emphasis>
+    
+     unknown parse/stringMarkup
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    
+      ✖ bg is not a valid attribute name for token
+    
+        2 │ <pad align="right" width="6"><emphasis> │ </emphasis></pad>                 
+    <error><emphasis>^</emphasis></error>
+        3 │ <pad align="right" width="6"><emphasis>  2 │ </emphasis></pad> <token
+    type="comment">//</token>
+      > 4 │ <pad align="right" width="6"><emphasis>  3 │ </emphasis></pad><token
+    type="punctuation">}</token><emphasis><token bg="red">a</token></emphasis></nobr>
+          │                                                                                         
+                            
+    ^
+    
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ━━━
+    
+    ✖ Found 1 problem
+    
+      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68896:9) generated source location
+      at StringMarkupParser.unexpected
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:73089:10) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3265:18) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parse
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3418:24) generated source location
+      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3432:6) generated source location
+      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:49437:3) generated source location
+      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:49459:9) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52453:12) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52483:24) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52468:9) generated source location
+      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:56491:11) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:56194:11) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68656:17) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52188:3) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68650:12) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68521:30) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68502:4) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68521:9) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68496:8) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68841:10) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68853:2) generated source location
+      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107377:3) generated source location
+      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
+    location
+      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107285:3) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107394:3) generated source location
+      at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
+      at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
+    (project-rome/@romejs/diagnostics/wrap.ts:28:16)
+      at ___R$project$rome$$romejs$core$test$worker$TestWorkerRunner_ts$default.runTest
+    (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:494:25)
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-✖ Found 1 problem
+  ✖ Found 1 problem
 
 ```
 
@@ -68,14 +291,128 @@ function hello(a, a) {
 
   ✖ Avoid duplicate function arguments. Check the a argument.
 
-  > 1 │ const hello = function (a, a) {
-      │                            ^
-    2 │  //
-    3 │ }a
+  ✖ Encountered an error displaying this diagnostic
+  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
+    <emphasis>token</emphasis>
+    
+     unknown parse/stringMarkup
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    
+      ✖ bg is not a valid attribute name for token
+    
+        2 │ <pad align="right" width="6"><emphasis> │ </emphasis></pad>                          
+    <error><emphasis>^</emphasis></error>
+        3 │ <pad align="right" width="6"><emphasis>  2 │ </emphasis></pad> <token
+    type="comment">//</token>
+      > 4 │ <pad align="right" width="6"><emphasis>  3 │ </emphasis></pad><token
+    type="punctuation">}</token><emphasis><token bg="red">a</token></emphasis></nobr>
+          │                                                                                         
+                            
+    ^
+    
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ━━━
+    
+    ✖ Found 1 problem
+    
+      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68896:9) generated source location
+      at StringMarkupParser.unexpected
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:73089:10) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3265:18) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3407:17) generated source location
+      at StringMarkupParser.parse
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3418:24) generated source location
+      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:3432:6) generated source location
+      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:49437:3) generated source location
+      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:49459:9) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52453:12) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52483:24) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52468:9) generated source location
+      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:56491:11) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:56194:11) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68656:17) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:52188:3) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68650:12) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68521:30) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68502:4) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68521:9) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68496:8) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68841:10) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:68853:2) generated source location
+      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107377:3) generated source location
+      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
+    location
+      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107285:3) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/noDupeArgs.test.t
+    s:107394:3) generated source location
+      at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
+      at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
+    (project-rome/@romejs/diagnostics/wrap.ts:28:16)
+      at ___R$project$rome$$romejs$core$test$worker$TestWorkerRunner_ts$default.runTest
+    (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:494:25)
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-✖ Found 1 problem
+  ✖ Found 1 problem
 
 ```
 

--- a/packages/@romejs/compiler/lint/rules/js/noUnusedVariables.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/noUnusedVariables.test.md
@@ -15,7 +15,7 @@
     const a = 4;
           ^
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -41,7 +41,7 @@ const a = 4;
     let a = 4;
         ^
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -69,7 +69,7 @@ let a = 4;
     2 │  console.log("foo");
     3 │ };
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
  unknown:1:13 lint/js/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -80,7 +80,7 @@ let a = 4;
     2 │  console.log("foo");
     3 │ };
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -110,7 +110,7 @@ function foo(myVar) {
     2 │  console.log("foo");
     3 │ }
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -141,7 +141,7 @@ foo();
     2 │  console.log("foo");
     3 │ };
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
  unknown:1:13 lint/js/noUnusedVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -152,7 +152,7 @@ foo();
     2 │  console.log("foo");
     3 │ };
 
-  ℹ Unused variables are dead code and usually result from incomplete refactoring.
+  ℹ Unused variables are dead code and usually the result of incomplete refactoring.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
@@ -309,10 +309,10 @@ while (x) {
     
       at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68896:9) generated source location
+    ents.test.ts:68892:9) generated source location
       at StringMarkupParser.unexpected
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:73089:10) generated source location
+    ents.test.ts:73085:10) generated source location
       at StringMarkupParser.parseTag
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
     ents.test.ts:3265:18) generated source location
@@ -381,21 +381,21 @@ while (x) {
     ents.test.ts:68496:8) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68841:10) generated source location
+    ents.test.ts:68837:10) generated source location
       at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68853:2) generated source location
+    ents.test.ts:68849:2) generated source location
       at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:107377:3) generated source location
+    ents.test.ts:107373:3) generated source location
       at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
     location
       at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:107285:3) generated source location
+    ents.test.ts:107281:3) generated source location
       at <anonymous>
     (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:107396:3) generated source location
+    ents.test.ts:107392:3) generated source location
       at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
       at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
     (project-rome/@romejs/diagnostics/wrap.ts:28:16)

--- a/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
@@ -284,127 +284,19 @@ while (x) {
 
   ✖ Block statements are preferred in this position.
 
-  ✖ Encountered an error displaying this diagnostic
-  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
-    <emphasis>token</emphasis>
-    
-     unknown parse/stringMarkup
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    
-      ✖ bg is not a valid attribute name for token
-    
-      > 1 │ <nobr>  <token type="keyword">with</token> <token type="punctuation">(</token><token
-    type="variable">x</token><token type="punctuation">)</token><token
-    type="punctuation">;</token><emphasis><token bg="red">with (x);</token></emphasis>
-          │                                                                                         
-                                                                                                    
-               ^
-        2 │  
-    <error><emphasis>^^^^^^^^^</emphasis></error></nobr>
-    
-    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-    ━━━
-    
-    ✖ Found 1 problem
-    
-      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68892:9) generated source location
-      at StringMarkupParser.unexpected
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:73085:10) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3265:18) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3407:17) generated source location
-      at StringMarkupParser.parseTag
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3329:25) generated source location
-      at StringMarkupParser.parseChild
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3407:17) generated source location
-      at StringMarkupParser.parse
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3418:24) generated source location
-      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:3432:6) generated source location
-      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:49437:3) generated source location
-      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:49459:9) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:52453:12) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:52483:24) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:52468:9) generated source location
-      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:56491:11) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:56194:11) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68656:17) generated source location
-      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:52188:3) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68650:12) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68521:30) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68502:4) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68521:9) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68496:8) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68837:10) generated source location
-      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:68849:2) generated source location
-      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:107373:3) generated source location
-      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
-    location
-      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:107281:3) generated source location
-      at <anonymous>
-    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
-    ents.test.ts:107392:3) generated source location
-      at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
-      at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
-    (project-rome/@romejs/diagnostics/wrap.ts:28:16)
-      at ___R$project$rome$$romejs$core$test$worker$TestWorkerRunner_ts$default.runTest
-    (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:494:25)
+    with (x);with (x);
+    ^^^^^^^^^
 
-  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  ℹ Recommended fix
 
-  ✖ Found 1 problem
+    1  │ - with (x);
+     1 │ + with (x) {
+     2 │ + 
+     3 │ + }
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✖ Found 1 problem
 
 ```
 

--- a/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
+++ b/packages/@romejs/compiler/lint/rules/js/preferBlockStatements.test.md
@@ -284,19 +284,127 @@ while (x) {
 
   ✖ Block statements are preferred in this position.
 
-    with (x);with (x);
-    ^^^^^^^^^
+  ✖ Encountered an error displaying this diagnostic
+  ✖ DiagnosticsError: <emphasis>bg</emphasis> is not a valid attribute name for
+    <emphasis>token</emphasis>
+    
+     unknown parse/stringMarkup
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    
+      ✖ bg is not a valid attribute name for token
+    
+      > 1 │ <nobr>  <token type="keyword">with</token> <token type="punctuation">(</token><token
+    type="variable">x</token><token type="punctuation">)</token><token
+    type="punctuation">;</token><emphasis><token bg="red">with (x);</token></emphasis>
+          │                                                                                         
+                                                                                                    
+               ^
+        2 │  
+    <error><emphasis>^^^^^^^^^</emphasis></error></nobr>
+    
+    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ━━━
+    
+    ✖ Found 1 problem
+    
+      at ___R$project$rome$$romejs$diagnostics$errors_ts$createSingleDiagnosticError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68896:9) generated source location
+      at StringMarkupParser.unexpected
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:73089:10) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3265:18) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3407:17) generated source location
+      at StringMarkupParser.parseTag
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3329:25) generated source location
+      at StringMarkupParser.parseChild
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3407:17) generated source location
+      at StringMarkupParser.parse
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3418:24) generated source location
+      at ___R$project$rome$$romejs$string$markup$parse_ts$parseMarkup
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:3432:6) generated source location
+      at ___R$$priv$project$rome$$romejs$string$markup$format_ts$renderGrid
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:49437:3) generated source location
+      at ___R$project$rome$$romejs$string$markup$format_ts$markupToPlainText
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:49459:9) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.markupify
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:52453:12) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logOne
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:52483:24) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.logAll
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:52468:9) generated source location
+      at ___R$$priv$project$rome$$romejs$cli$diagnostics$printAdvice_ts$printFrame
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:56491:11) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$printAdvice_ts$default
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:56194:11) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68656:17) generated source location
+      at ___R$project$rome$$romejs$cli$reporter$Reporter_ts$default.indent
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:52188:3) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostic
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68650:12) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68521:30) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.wrapError
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68502:4) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.displayDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68521:9) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$DiagnosticsPrinter_ts$default.print
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68496:8) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnostics
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68841:10) generated source location
+      at ___R$project$rome$$romejs$cli$diagnostics$index_ts$printDiagnosticsToString
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:68853:2) generated source location
+      at ___R$$priv$project$rome$$romejs$compiler$lint$utils$testing_ts$testLintExpect
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:107377:3) generated source location
+      at process.processTicksAndRejections (internal/process/task_queues.js:97:4) generated source
+    location
+      at ___R$project$rome$$romejs$compiler$lint$utils$testing_ts$testLint
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:107285:3) generated source location
+      at <anonymous>
+    (/Users/sebastianmckenzie/Projects/rome/packages/@romejs/compiler/lint/rules/js/preferBlockStatem
+    ents.test.ts:107396:3) generated source location
+      at <anonymous> (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:499:5)
+      at ___R$project$rome$$romejs$diagnostics$wrap_ts$catchDiagnostics
+    (project-rome/@romejs/diagnostics/wrap.ts:28:16)
+      at ___R$project$rome$$romejs$core$test$worker$TestWorkerRunner_ts$default.runTest
+    (project-rome/@romejs/core/test-worker/TestWorkerRunner.ts:494:25)
 
-  ℹ Recommended fix
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-    1  │ - with (x);
-     1 │ + with (x) {
-     2 │ + 
-     3 │ + }
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-✖ Found 1 problem
+  ✖ Found 1 problem
 
 ```
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/altText.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/altText.test.md
@@ -15,8 +15,8 @@
     <img src='foo' />
     ^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -42,8 +42,8 @@
     <img {...props} />
     ^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -69,8 +69,8 @@
     <img {...props} alt={undefined} />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -96,8 +96,8 @@
     <img src='foo' role='presentation' />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -123,8 +123,8 @@
     <img src='foo' role='none' />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -150,8 +150,8 @@
     <object {...props} />
     ^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -177,8 +177,8 @@
     <object aria-label={undefined} />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -204,8 +204,8 @@
     <area {...props} />
     ^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -231,8 +231,8 @@
     <area alt={undefined} />
     ^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -258,8 +258,8 @@
     <input type='image' {...props} />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -285,8 +285,8 @@
     <input type='image' {...props} alt={undefined} />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Meaningful alternative text on elements that require it helps users relying on screen readers to
-    understand content's purpose within a page.
+  ℹ Meaningful alternative text on elements helps users relying on screen readers to understand
+    content's purpose within a page.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/ariaUnsupportedElements.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/ariaUnsupportedElements.test.md
@@ -10,7 +10,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <meta charset='UTF-8' aria-hidden='false' />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +37,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <meta charset='UTF-8' role='meta' />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -62,7 +64,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <html aria-required='true' />
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -88,7 +91,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <html role='html'></html>
     ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +118,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <script aria-label='script'></script>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -140,7 +145,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <script role='script'></script>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +172,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <style aria-labelledby></style>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -192,7 +199,8 @@
 
  unknown:1 lint/jsx-a11y/ariaUnsupportedElements ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and styleelements.
+  ✖ Avoid the role attribute and aria-* attributes when using meta, html, script, and style
+    elements.
 
     <style role='style'></style>
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/mediaHasCaption.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/mediaHasCaption.test.md
@@ -15,8 +15,8 @@
     <audio {...props} />
     ^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Captions support users with hearing-impairments. They should be a transcription or translationof
-    the dialogue, sound effects, musical cues, and other relevant audio information.
+  ℹ Captions support users with hearing-impairments. They should be a transcription or translation
+    of the dialogue, sound effects, musical cues, and other relevant audio information.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -42,8 +42,8 @@
     <video {...props} />
     ^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Captions support users with hearing-impairments. They should be a transcription or translationof
-    the dialogue, sound effects, musical cues, and other relevant audio information.
+  ℹ Captions support users with hearing-impairments. They should be a transcription or translation
+    of the dialogue, sound effects, musical cues, and other relevant audio information.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -69,8 +69,8 @@
     <audio>child</audio>
     ^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Captions support users with hearing-impairments. They should be a transcription or translationof
-    the dialogue, sound effects, musical cues, and other relevant audio information.
+  ℹ Captions support users with hearing-impairments. They should be a transcription or translation
+    of the dialogue, sound effects, musical cues, and other relevant audio information.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -96,8 +96,8 @@
     <video>child</audio>
     ^^^^^^^^^^^^^^^^^^^^
 
-  ℹ Captions support users with hearing-impairments. They should be a transcription or translationof
-    the dialogue, sound effects, musical cues, and other relevant audio information.
+  ℹ Captions support users with hearing-impairments. They should be a transcription or translation
+    of the dialogue, sound effects, musical cues, and other relevant audio information.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/compiler/lint/rules/jsx-a11y/noAccessKey.test.md
+++ b/packages/@romejs/compiler/lint/rules/jsx-a11y/noAccessKey.test.md
@@ -16,8 +16,8 @@
     <input accessKey="key" />
            ^^^^^^^^^^^^^^^
 
-  ℹ Assigning keyboard shortcuts using the accessKey attribute leads to inconsistent keyboardactions
-    across applications.
+  ℹ Assigning keyboard shortcuts using the accessKey attribute leads to inconsistent keyboard
+    actions across applications.
 
   ℹ Recommended fix
 
@@ -49,8 +49,8 @@
     <input accessKey={key} />
            ^^^^^^^^^^^^^^^
 
-  ℹ Assigning keyboard shortcuts using the accessKey attribute leads to inconsistent keyboardactions
-    across applications.
+  ℹ Assigning keyboard shortcuts using the accessKey attribute leads to inconsistent keyboard
+    actions across applications.
 
   ℹ Recommended fix
 

--- a/packages/@romejs/compiler/lint/rules/react/noDirectMutationState.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/noDirectMutationState.test.md
@@ -19,8 +19,8 @@
     5 │               return <div>Hello {this.props.name}</div>;
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -55,8 +55,8 @@ class Hello extends React.Component {
     5 │               return <div>Hello {this.props.name}</div>;
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -91,8 +91,8 @@ class Hello extends React.Component {
     5 │               return <div>Hello {this.props.name}</div>;
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -127,8 +127,8 @@ class Hello extends React.Component {
     5 │               return <div>Hello {this.props.name}</div>;
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -163,8 +163,8 @@ class Hello extends React.Component {
     5 │                 return <div>Hello</div>;
     6 │               }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -199,8 +199,8 @@ class Hello extends React.Component {
     5 │                 this.state.person.name.last = "baz";
     6 │                 return <div>Hello</div>;
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
  unknown:5:16 lint/react/noDirectMutationState ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -213,8 +213,8 @@ class Hello extends React.Component {
     6 │                 return <div>Hello</div>;
     7 │               }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -250,8 +250,8 @@ class Hello extends React.Component {
     8 │               }
     9 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -288,8 +288,8 @@ class Hello extends React.Component {
     7 │                 });
     8 │               }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -326,8 +326,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -361,8 +361,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -396,8 +396,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -431,8 +431,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -466,8 +466,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -501,8 +501,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -536,8 +536,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -571,8 +571,8 @@ class Hello extends React.Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -606,8 +606,8 @@ class Hello extends Component {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -641,8 +641,8 @@ class Hello extends React.PureComponent {
     5 │               }
     6 │             }
 
-  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. Theonly
-    place you may set this.state directly is in a constructor of a react class component.
+  ℹ Calling setState() after mutating this.state directly may replace the mutation you made. The
+    only place you may set this.state directly is in a constructor of a react class component.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/compiler/lint/rules/react/noWillUpdateSetState.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/noWillUpdateSetState.test.md
@@ -19,8 +19,8 @@
     4 │    name: 'John'
     5 │   });
 
-  ℹ Updating state immediately before a scheduled render causes a second render that can causevisual
-    layout thrashing.
+  ℹ Updating state immediately before a scheduled render causes a second render that can cause
+    visual layout thrashing.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -56,8 +56,8 @@ class Hello extends React.Component {
     5 │    name: 'John'
     6 │   });
 
-  ℹ Updating state immediately before a scheduled render causes a second render that can causevisual
-    layout thrashing.
+  ℹ Updating state immediately before a scheduled render causes a second render that can cause
+    visual layout thrashing.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -94,8 +94,8 @@ class Hello extends React.Component {
     4 │    name: 'John'
     5 │   });
 
-  ℹ Updating state immediately before a scheduled render causes a second render that can causevisual
-    layout thrashing.
+  ℹ Updating state immediately before a scheduled render causes a second render that can cause
+    visual layout thrashing.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -131,8 +131,8 @@ class Hello extends Component {
     5 │    name: 'John'
     6 │   });
 
-  ℹ Updating state immediately before a scheduled render causes a second render that can causevisual
-    layout thrashing.
+  ℹ Updating state immediately before a scheduled render causes a second render that can cause
+    visual layout thrashing.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -169,8 +169,8 @@ class Hello extends Component {
     4 │    name: 'John'
     5 │   });
 
-  ℹ Updating state immediately before a scheduled render causes a second render that can causevisual
-    layout thrashing.
+  ℹ Updating state immediately before a scheduled render causes a second render that can cause
+    visual layout thrashing.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -206,8 +206,8 @@ class Hello extends React.Component {
     4 │    name: 'John'
     5 │   });
 
-  ℹ Updating state immediately before a scheduled render causes a second render that can causevisual
-    layout thrashing.
+  ℹ Updating state immediately before a scheduled render causes a second render that can cause
+    visual layout thrashing.
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/core/common/types/client.ts
+++ b/packages/@romejs/core/common/types/client.ts
@@ -11,6 +11,7 @@ import {
 } from "@romejs/cli-diagnostics";
 import {Platform} from "./platform";
 import {AbsoluteFilePath, CWD_PATH} from "@romejs/path";
+import {ReporterStream} from "@romejs/cli-reporter";
 
 export const DEFAULT_CLIENT_FLAGS: ClientFlags = {
 	clientName: "unknown",
@@ -47,6 +48,12 @@ export type ClientRequestFlags = DiagnosticsPrinterFlags & {
 	resolverPlatform: undefined | Platform;
 	resolverScale: undefined | number;
 	resolverMocks: boolean;
+};
+
+export type ClientReporterOverrides = {
+	redirectError?: boolean;
+	format?: ReporterStream["format"];
+	columns?: number;
 };
 
 export type ClientFlags = {

--- a/packages/@romejs/core/common/userConfig.ts
+++ b/packages/@romejs/core/common/userConfig.ts
@@ -8,17 +8,15 @@
 import {consumeJSON} from "@romejs/codec-json";
 import {VERSION} from "./constants";
 import {ROME_CONFIG_FILENAMES} from "@romejs/project";
-import {
-	AbsoluteFilePath,
-	HOME_PATH,
-	TEMP_PATH,
-	createAbsoluteFilePath,
-} from "@romejs/path";
+import {AbsoluteFilePath, HOME_PATH, TEMP_PATH} from "@romejs/path";
 import {existsSync, readFileTextSync} from "@romejs/fs";
+import {Consumer} from "@romejs/consume";
+import {descriptions} from "@romejs/diagnostics";
 
 export type UserConfig = {
 	runtimeModulesPath: AbsoluteFilePath;
 	cachePath: AbsoluteFilePath;
+	syntaxTheme: undefined | Consumer;
 };
 
 const VERSION_PATH = TEMP_PATH.append(`rome-${VERSION}`);
@@ -26,6 +24,7 @@ const VERSION_PATH = TEMP_PATH.append(`rome-${VERSION}`);
 export const DEFAULT_USER_CONFIG: UserConfig = {
 	runtimeModulesPath: VERSION_PATH.append("runtime"),
 	cachePath: VERSION_PATH.append("cache"),
+	syntaxTheme: undefined,
 };
 
 export function loadUserConfig(): UserConfig {
@@ -47,15 +46,34 @@ export function loadUserConfig(): UserConfig {
 		};
 
 		if (consumer.has("cachePath")) {
-			userConfig.cachePath = createAbsoluteFilePath(
-				consumer.get("cachePath").asString(),
+			userConfig.cachePath = consumer.get("cachePath").asAbsoluteFilePath(
+				undefined,
+				configPath.getParent(),
 			);
 		}
 
 		if (consumer.has("runtimeModulesPath")) {
-			userConfig.runtimeModulesPath = createAbsoluteFilePath(
-				consumer.get("runtimeModulesPath").asString(),
+			userConfig.runtimeModulesPath = consumer.get("runtimeModulesPath").asAbsoluteFilePath(
+				undefined,
+				configPath.getParent(),
 			);
+		}
+
+		if (consumer.has("vscodeTheme")) {
+			const prop = consumer.get("vscodeTheme");
+			const path = prop.asAbsoluteFilePath(undefined, configPath.getParent());
+
+			if (existsSync(path)) {
+				const input = readFileTextSync(path);
+
+				userConfig.syntaxTheme = consumeJSON({
+					consumeDiagnosticCategory: "parse/vscodeTheme",
+					input,
+					path,
+				});
+			} else {
+				throw prop.unexpected(descriptions.USER_CONFIG.VSCODE_THEME_NOT_FOUND);
+			}
 		}
 
 		consumer.enforceUsedProperties("config property");

--- a/packages/@romejs/core/integrationTestHelpers.ts
+++ b/packages/@romejs/core/integrationTestHelpers.ts
@@ -79,6 +79,7 @@ export function createIntegrationTest(
 		const userConfig: UserConfig = {
 			cachePath,
 			runtimeModulesPath: virtualModulesPath,
+			syntaxTheme: undefined,
 		};
 
 		try {

--- a/packages/@romejs/core/server/Server.ts
+++ b/packages/@romejs/core/server/Server.ts
@@ -223,6 +223,7 @@ export default class Server {
 					},
 				],
 				markupOptions: {
+					userConfig: this.userConfig,
 					humanizeFilename: (filename) => {
 						const path = createUnknownFilePath(filename);
 						if (path.isAbsolute()) {
@@ -645,8 +646,8 @@ export default class Server {
 			streams: [outStream, errStream],
 			verbose: flags.verbose,
 			markupOptions: {
-				cwd: flags.cwd,
 				...this.logger.markupOptions,
+				cwd: flags.cwd,
 			},
 			useRemoteProgressBars: useRemoteReporter,
 		});

--- a/packages/@romejs/core/server/commands/check.test.md
+++ b/packages/@romejs/core/server/commands/check.test.md
@@ -8,14 +8,14 @@
 
 ```
 
- project/index.js:1 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ index.js:1 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ The unknownVariable variable is undeclared
 
     unknownVariable
     ^^^^^^^^^^^^^^^
 
- project/index.js lint/pendingFixes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ index.js lint/pendingFixes  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Pending formatting and recommended autofixes
 
@@ -40,54 +40,6 @@ $ rome lint --review
 ```
 # index.js
 unknownVariable
-
-# rome.json
-{
-	"files": {
-		"vendorPath": "../remote"
-	}
-}
-
-```
-
-## `smoke save`
-
-### `console`
-
-```
-
- project/index.js:1:4 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ✖ The unformatted variable is undeclared
-
-  > 1 │ if (unformatted) {
-      │     ^^^^^^^^^^^
-    2 │  swag;
-    3 │ }
-
- project/index.js:2:1 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-  ✖ The swag variable is undeclared
-
-    1 │ if (unformatted) {
-  > 2 │  swag;
-      │  ^^^^
-    3 │ }
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-✔ 1 file updated
-✖ Found 2 problems
-
-```
-
-### `files`
-
-```
-# index.js
-if (unformatted) {
-	swag;
-}
 
 # rome.json
 {

--- a/packages/@romejs/core/server/commands/check.test.md
+++ b/packages/@romejs/core/server/commands/check.test.md
@@ -49,3 +49,51 @@ unknownVariable
 }
 
 ```
+
+## `smoke save`
+
+### `console`
+
+```
+
+ index.js:1:4 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ The unformatted variable is undeclared
+
+  > 1 │ if (unformatted) {
+      │     ^^^^^^^^^^^
+    2 │  swag;
+    3 │ }
+
+ index.js:2:1 lint/js/undeclaredVariables ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ✖ The swag variable is undeclared
+
+    1 │ if (unformatted) {
+  > 2 │  swag;
+      │  ^^^^
+    3 │ }
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✔ 1 file updated
+✖ Found 2 problems
+
+```
+
+### `files`
+
+```
+# index.js
+if (unformatted) {
+	swag;
+}
+
+# rome.json
+{
+	"files": {
+		"vendorPath": "../remote"
+	}
+}
+
+```

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -37,6 +37,7 @@ export type DiagnosticCategory =
 	| "parse/stringMarkup"
 	| "parse/url"
 	| "parse/url/query"
+	| "parse/vscodeTheme"
 	| "projectManager/incorrectConfigFilename"
 	| "projectManager/missing"
 	| "projectManager/nameCollision"

--- a/packages/@romejs/diagnostics/descriptions/index.ts
+++ b/packages/@romejs/diagnostics/descriptions/index.ts
@@ -35,6 +35,7 @@ import {consume} from "./consume";
 import {manifest} from "./manifest";
 import {projectConfig} from "./projectConfig";
 import {lint} from "./lint";
+import {userConfig} from "./userConfig";
 
 type DiagnosticMetadataString = Omit<Partial<DiagnosticDescription>, "message"> & {
 	message: string;
@@ -173,4 +174,5 @@ export const descriptions = {
 	CONSUME: consume,
 	MANIFEST: manifest,
 	PROJECT_CONFIG: projectConfig,
+	USER_CONFIG: userConfig,
 };

--- a/packages/@romejs/diagnostics/descriptions/lint.ts
+++ b/packages/@romejs/diagnostics/descriptions/lint.ts
@@ -310,7 +310,7 @@ export const lint = createDiagnosticsCategory({
 			{
 				type: "log",
 				category: "info",
-				text: "Meaningful alternative text on elements that require it helps users relying on screen readers to understand content's purpose within a page.",
+				text: "Meaningful alternative text on elements helps users relying on screen readers to understand content's purpose within a page.",
 			},
 		],
 	},
@@ -626,7 +626,7 @@ export const lint = createDiagnosticsCategory({
 			{
 				type: "log",
 				category: "info",
-				text: "Unused variables are dead code and usually result from incomplete refactoring.",
+				text: "Unused variables are dead code and usually the result of incomplete refactoring.",
 			},
 		],
 	}),

--- a/packages/@romejs/diagnostics/descriptions/stringMarkup.ts
+++ b/packages/@romejs/diagnostics/descriptions/stringMarkup.ts
@@ -22,6 +22,13 @@ export const stringMarkup = createDiagnosticsCategory({
 			},
 		],
 	}),
+	INVALID_ATTRIBUTE_VALUE: (
+		tagName: string,
+		attributeName: string,
+		attributeValue: string,
+	) => ({
+		message: markup`<emphasis>${attributeValue}</emphasis> is not a valid attribute value for <emphasis>${attributeName}</emphasis> in a <emphasis>${tagName}</emphasis>`,
+	}),
 	INVALID_ATTRIBUTE_NAME_FOR_TAG: (
 		tagName: string,
 		attributeName: string,

--- a/packages/@romejs/diagnostics/descriptions/userConfig.ts
+++ b/packages/@romejs/diagnostics/descriptions/userConfig.ts
@@ -1,0 +1,5 @@
+import {createDiagnosticsCategory} from "./index";
+
+export const userConfig = createDiagnosticsCategory({
+	VSCODE_THEME_NOT_FOUND: "VSCode theme not found",
+});

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -333,10 +333,12 @@ function pushComment(
 	}
 
 	if (parser.shouldCreateToken()) {
-		/*parser.pushToken({
-      type: tt.comment,
-      loc,
-    });*/
+		parser.pushToken({
+			type: tt.comment,
+			start: opts.startPos.index,
+			end: opts.endPos.index,
+			loc,
+		});
 	}
 
 	return comment;

--- a/packages/@romejs/string-markup/ansi.ts
+++ b/packages/@romejs/string-markup/ansi.ts
@@ -34,29 +34,11 @@ export const formatAnsi = {
 	hyperlink(name: string, href: string): string {
 		return `\u001b]8;;${href}\u0007${name}\u001b]8;;\u0007`;
 	},
-	rgb(
-		str: string,
-		color: {
-			r: number;
-			g: number;
-			b: number;
-		},
-	): string {
-		return `\u001b[38;2;${String(color.r)};${String(color.g)};${String(color.b)}m${str}${createEscape(
-			39,
-		)}`;
+	rgb(str: string, color: [number, number, number]): string {
+		return `\u001b[38;2;${color.join(";")}m${str}${createEscape(39)}`;
 	},
-	bgRgb(
-		str: string,
-		color: {
-			r: number;
-			g: number;
-			b: number;
-		},
-	): string {
-		return `\u001b[48;2;${String(color.r)};${String(color.g)};${String(color.b)}m${str}${createEscape(
-			49,
-		)}`;
+	bgRgb(str: string, color: [number, number, number]): string {
+		return `\u001b[48;2;${color.join(";")}m${str}${createEscape(49)}`;
 	},
 	bold(str: string): string {
 		return createEscape(1) + str + createEscape(22);

--- a/packages/@romejs/string-markup/format.ts
+++ b/packages/@romejs/string-markup/format.ts
@@ -7,6 +7,7 @@
 
 import {
 	Children,
+	GridOutputFormat,
 	MarkupFormatGridOptions,
 	MarkupFormatNormalizeOptions,
 	MarkupLinesAndWidth,
@@ -14,14 +15,14 @@ import {
 } from "./types";
 import {parseMarkup} from "./parse";
 import {escapeMarkup} from "./escape";
-import Grid from "./Grid";
+import Grid from "./grid/Grid";
 import {ob1Get1} from "@romejs/ob1";
 import {sliceEscaped} from "@romejs/string-utils";
 import {
 	formatGrammarNumber,
 	getFileLinkFilename,
 	getFileLinkText,
-} from "./tagFormatters";
+} from "./grid/tagFormatters";
 
 function buildTag(
 	tag: TagNode,
@@ -128,6 +129,19 @@ function normalizeMarkupChildren(
 	};
 }
 
+function renderGrid(
+	input: string,
+	opts: MarkupFormatGridOptions = {},
+	format: GridOutputFormat,
+): MarkupLinesAndWidth {
+	const grid = new Grid(opts);
+	grid.drawRoot(parseMarkup(input));
+	return {
+		width: ob1Get1(grid.getWidth()),
+		lines: grid.getLines(format),
+	};
+}
+
 export function markupToPlainTextString(
 	input: string,
 	opts: MarkupFormatGridOptions = {},
@@ -139,26 +153,21 @@ export function markupToPlainText(
 	input: string,
 	opts: MarkupFormatGridOptions = {},
 ): MarkupLinesAndWidth {
-	const grid = new Grid(opts);
-	grid.drawRoot(parseMarkup(input));
-	return {
-		width: ob1Get1(grid.getWidth()),
-		lines: grid.getLines(),
-	};
+	return renderGrid(input, opts, "none");
 }
 
 export function markupToAnsi(
 	input: string,
 	opts: MarkupFormatGridOptions = {},
 ): MarkupLinesAndWidth {
-	const grid = new Grid(opts);
+	return renderGrid(input, opts, "ansi");
+}
 
-	grid.drawRoot(parseMarkup(input));
-
-	return {
-		width: ob1Get1(grid.getWidth()),
-		lines: grid.getFormattedLines(),
-	};
+export function markupToHtml(
+	input: string,
+	opts: MarkupFormatGridOptions = {},
+): MarkupLinesAndWidth {
+	return renderGrid(input, opts, "html");
 }
 
 export function normalizeMarkup(

--- a/packages/@romejs/string-markup/grid/ansi.ts
+++ b/packages/@romejs/string-markup/grid/ansi.ts
@@ -1,0 +1,340 @@
+import {
+	MarkupColor,
+	MarkupFormatOptions,
+	MarkupTokenType,
+	TagNode,
+} from "../types";
+import {formatAnsi} from "../ansi";
+import {
+	getFileLinkFilename,
+	normalizeColor,
+	normalizeTokenType,
+} from "./tagFormatters";
+import OneDarkPro from "../syntax-theme/OneDarkPro.json";
+import {Dict} from "@romejs/typescript-helpers";
+import {Consumer, consumeUnknown} from "@romejs/consume";
+
+export function ansiFormatText(
+	{name: tagName, attributes}: TagNode,
+	value: string,
+	opts: MarkupFormatOptions,
+): string {
+	switch (tagName) {
+		case "hyperlink": {
+			return formatAnsi.hyperlink(attributes.target || "", value);
+		}
+
+		case "filelink": {
+			const filename = getFileLinkFilename(attributes, opts);
+			return formatAnsi.hyperlink(value, `file://${filename}`);
+		}
+
+		case "inverse":
+			return formatAnsi.inverse(value);
+
+		case "emphasis":
+			return formatAnsi.bold(value);
+
+		case "dim":
+			return formatAnsi.dim(value);
+
+		case "italic":
+			return formatAnsi.italic(value);
+
+		case "underline":
+			return formatAnsi.underline(value);
+
+		case "strike":
+			return formatAnsi.strikethrough(value);
+
+		case "error":
+			return formatAnsi.red(value);
+
+		case "success":
+			return formatAnsi.green(value);
+
+		case "warn":
+			return formatAnsi.yellow(value);
+
+		case "info":
+			return formatAnsi.blue(value);
+
+		case "command":
+			return formatAnsi.italic(value);
+
+		case "highlight": {
+			const index = Math.min(0, Number(attributes.i) || 0);
+			const fn = ansiHighlightFactories[index % ansiHighlightFactories.length];
+			return fn(value);
+		}
+
+		case "color":
+			return formatAnsiBackground(
+				normalizeColor(attributes.bg),
+				formatAnsiForeground(normalizeColor(attributes.fg), value),
+			);
+
+		case "token":
+			return formatToken(normalizeTokenType(attributes.type), value, opts);
+
+		default:
+			return value;
+	}
+}
+
+type FontStyle = "normal" | "italic";
+
+type TokenFormat = {
+	rgb?: [number, number, number];
+	fontStyle?: FontStyle;
+};
+
+type TokenFormats = {[type in MarkupTokenType]?: TokenFormat};
+
+const tokenTypeToScope: Dict<MarkupTokenType> = {
+	"constant.numeric": "number",
+	"string.regexp": "regex",
+	"string": "string",
+	"comment": "comment",
+	//"": "operator",
+	//"": "punctuation",
+	"variable": "variable",
+	"keyword": "keyword",
+	"entity.other.attribute-name": "attr-name",
+	"entity.other.attribute-name.js": "attr-name",
+};
+
+function normalizeFontStyle(style: undefined | string): FontStyle {
+	switch (style) {
+		case "italic":
+			return style;
+
+		default:
+			return "normal";
+	}
+}
+
+const tokenColorsCache: Map<Consumer, TokenFormats> = new Map();
+let defaultTokenColors: undefined | TokenFormats;
+
+function getTokenColors(consumer: undefined | Consumer): TokenFormats {
+	if (consumer === undefined) {
+		if (defaultTokenColors === undefined) {
+			defaultTokenColors = getTokenColors(
+				consumeUnknown(OneDarkPro, "parse/vscodeTheme"),
+			);
+		}
+
+		return defaultTokenColors;
+	}
+
+	const cached = tokenColorsCache.get(consumer);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const tokenTypeFormat: TokenFormats = {};
+	tokenColorsCache.set(consumer, tokenTypeFormat);
+
+	for (const prop of consumer.get("tokenColors").asArray()) {
+		const settings = prop.get("settings");
+		const scope = prop.get("scope");
+		const scopes = Array.isArray(scope.asUnknown())
+			? scope.asArray().map((elem) => elem.asString())
+			: scope.asString().split(",").map((scope) => scope.trim());
+
+		for (const scope of scopes) {
+			const tokenType = tokenTypeToScope[scope];
+			if (tokenType !== undefined) {
+				const existing = tokenTypeFormat[tokenType];
+
+				const newSettings: TokenFormat = {};
+
+				if (settings.has("foreground")) {
+					newSettings.rgb = hexToRgb(settings.get("foreground").asString());
+				}
+
+				if (settings.has("fontStyle")) {
+					newSettings.fontStyle = normalizeFontStyle(
+						settings.get("fontStyle").asString(),
+					);
+				}
+
+				tokenTypeFormat[tokenType] = {
+					...existing,
+					...newSettings,
+				};
+			}
+		}
+	}
+
+	return tokenTypeFormat;
+}
+
+function formatToken(
+	type: undefined | MarkupTokenType,
+	value: string,
+	opts: MarkupFormatOptions,
+): string {
+	if (type === undefined) {
+		return value;
+	}
+
+	const tokenTypeFormat = getTokenColors((opts?.userConfig)?.syntaxTheme);
+	const format = tokenTypeFormat[type];
+
+	if (format === undefined) {
+		return value;
+	}
+
+	if (format.fontStyle === "italic") {
+		value = formatAnsi.italic(value);
+	}
+
+	if (format.rgb === undefined) {
+		return value;
+	}
+
+	return formatAnsi.rgb(value, format.rgb);
+}
+
+function hexToRgb(hex: undefined | string): [number, number, number] {
+	if (hex === undefined) {
+		throw new Error("No color string passed");
+	}
+
+	const match = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+	if (match == null) {
+		throw new Error(`${hex} is not a valid hex color`);
+	}
+
+	return [
+		parseInt(match[1], 16),
+		parseInt(match[2], 16),
+		parseInt(match[3], 16),
+	];
+}
+
+// TODO fill this
+const ansiHighlightFactories: Array<(str: string) => string> = [
+	formatAnsi.magenta,
+	formatAnsi.cyan,
+];
+
+function formatAnsiBackground(bg: undefined | MarkupColor, text: string): string {
+	if (bg === undefined) {
+		return text;
+	}
+
+	switch (bg) {
+		case "black":
+			return formatAnsi.bgBlack(text);
+
+		case "brightBlack":
+			return formatAnsi.bgBrightBlack(text);
+
+		case "red":
+			return formatAnsi.bgRed(text);
+
+		case "brightRed":
+			return formatAnsi.bgBrightRed(text);
+
+		case "green":
+			return formatAnsi.bgGreen(text);
+
+		case "brightGreen":
+			return formatAnsi.bgBrightGreen(text);
+
+		case "yellow":
+			return formatAnsi.bgYellow(text);
+
+		case "brightYellow":
+			return formatAnsi.bgBrightYellow(text);
+
+		case "blue":
+			return formatAnsi.bgBlue(text);
+
+		case "brightBlue":
+			return formatAnsi.bgBrightBlue(text);
+
+		case "magenta":
+			return formatAnsi.bgMagenta(text);
+
+		case "brightMagenta":
+			return formatAnsi.bgBrightMagenta(text);
+
+		case "cyan":
+			return formatAnsi.bgCyan(text);
+
+		case "brightCyan":
+			return formatAnsi.bgBrightCyan(text);
+
+		case "white":
+			return formatAnsi.bgWhite(text);
+
+		case "brightWhite":
+			return formatAnsi.bgBrightWhite(text);
+
+		default:
+			return text;
+	}
+}
+
+function formatAnsiForeground(fg: undefined | MarkupColor, text: string): string {
+	if (fg === undefined) {
+		return text;
+	}
+
+	switch (fg) {
+		case "black":
+			return formatAnsi.black(text);
+
+		case "brightBlack":
+			return formatAnsi.brightBlack(text);
+
+		case "red":
+			return formatAnsi.red(text);
+
+		case "brightRed":
+			return formatAnsi.brightRed(text);
+
+		case "green":
+			return formatAnsi.green(text);
+
+		case "brightGreen":
+			return formatAnsi.brightGreen(text);
+
+		case "yellow":
+			return formatAnsi.yellow(text);
+
+		case "brightYellow":
+			return formatAnsi.brightYellow(text);
+
+		case "blue":
+			return formatAnsi.blue(text);
+
+		case "brightBlue":
+			return formatAnsi.brightBlue(text);
+
+		case "magenta":
+			return formatAnsi.magenta(text);
+
+		case "brightMagenta":
+			return formatAnsi.brightMagenta(text);
+
+		case "cyan":
+			return formatAnsi.cyan(text);
+
+		case "brightCyan":
+			return formatAnsi.brightCyan(text);
+
+		case "white":
+			return formatAnsi.white(text);
+
+		case "brightWhite":
+			return formatAnsi.brightWhite(text);
+
+		default:
+			return text;
+	}
+}

--- a/packages/@romejs/string-markup/grid/html.ts
+++ b/packages/@romejs/string-markup/grid/html.ts
@@ -1,0 +1,85 @@
+import {TagNode} from "../types";
+import {escapeXHTMLEntities} from "@romejs/js-parser";
+import {normalizeColor} from "./tagFormatters";
+
+export function htmlFormatText(
+	{name: tagName, attributes}: TagNode,
+	value: string,
+): string {
+	switch (tagName) {
+		case "hyperlink": {
+			return `<a href="${escapeXHTMLEntities(attributes.target || "")}">${value}</a>`;
+		}
+
+		case "filelink": {
+			// We probably don't need filelinks if it's just for presentation in the browser?
+			//const filename = getFileLinkFilename(attributes, opts);
+			//return `<a href="file://${escapeXHTMLEntities(filename)}">${value}</a>`;
+			return `<span style="text-decoration-style: dotted;">${value}</span>`;
+		}
+
+		case "inverse":
+			return `<span style="color: white; background-color: #ddd;">${value}</span>`;
+
+		case "emphasis":
+			return `<strong>${value}</strong>`;
+
+		case "dim":
+			return `<span style="opacity: 0.8;">${value}</span>"`;
+
+		case "italic":
+			return `<i>${value}</i>"`;
+
+		case "underline":
+			return `<u>${value}</u>"`;
+
+		case "strike":
+			return `<strike>${value}</strike>"`;
+
+		case "error":
+			return `<span style="color: Tomato;">${value}</span>`;
+
+		case "success":
+			return `<span style="color: MediumSeaGreen;">${value}</span>`;
+
+		case "warn":
+			return `<span style="color: Orange;">${value}</span>`;
+
+		case "info":
+			return `<span style="color: DodgerBlue;">${value}</span>`;
+
+		case "command":
+			return `<i>${value}</i>`;
+
+		case "highlight": {
+			const index = Math.min(0, Number(attributes.i) || 0);
+			const color = highlightColors[index % highlightColors.length];
+			return `<span style="color: ${color};">${value}</span>`;
+		}
+
+		case "color": {
+			const styles = [];
+
+			const fg = normalizeColor(attributes.fg);
+			if (fg !== undefined) {
+				styles.push(`color: ${fg}`);
+			}
+
+			const bg = normalizeColor(attributes.bg);
+			if (bg !== undefined) {
+				styles.push(`background-color: ${bg}`);
+			}
+
+			return `<span style="${styles.join("; ")}">${value}</span>`;
+		}
+
+		case "token":
+			return `<span class="token ${attributes.type || ""}">${value}</span>`;
+
+		default:
+			return value;
+	}
+}
+
+// TODO fill this with more
+const highlightColors = ["magenta", "cyan"];

--- a/packages/@romejs/string-markup/grid/tagFormatters.ts
+++ b/packages/@romejs/string-markup/grid/tagFormatters.ts
@@ -5,9 +5,61 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {MarkupFormatOptions, TagAttributes} from "./types";
+import {
+	MarkupColor,
+	MarkupFormatOptions,
+	MarkupTokenType,
+	TagAttributes,
+} from "../types";
 import {humanizeNumber} from "@romejs/string-utils";
 import {createUnknownFilePath} from "@romejs/path";
+
+export function normalizeTokenType(
+	type: undefined | string,
+): undefined | MarkupTokenType {
+	switch (type) {
+		case "keyword":
+		case "number":
+		case "regex":
+		case "string":
+		case "comment":
+		case "operator":
+		case "punctuation":
+		case "variable":
+		case "attr-name":
+			return type;
+
+		default:
+			return undefined;
+	}
+}
+
+export function normalizeColor(
+	color: undefined | string,
+): undefined | MarkupColor {
+	switch (color) {
+		case "black":
+		case "brightBlack":
+		case "red":
+		case "brightRed":
+		case "green":
+		case "brightGreen":
+		case "yellow":
+		case "brightYellow":
+		case "blue":
+		case "brightBlue":
+		case "magenta":
+		case "brightMagenta":
+		case "cyan":
+		case "brightCyan":
+		case "white":
+		case "brightWhite":
+			return color;
+
+		default:
+			return undefined;
+	}
+}
 
 export function humanizeMarkupFilename(
 	filename: string,

--- a/packages/@romejs/string-markup/syntax-theme/LICENSE
+++ b/packages/@romejs/string-markup/syntax-theme/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2019 Binaryify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/@romejs/string-markup/syntax-theme/OneDarkPro.json
+++ b/packages/@romejs/string-markup/syntax-theme/OneDarkPro.json
@@ -1,0 +1,1916 @@
+{
+	"name": "One Dark Pro",
+	"type": "dark",
+	"semanticHighlighting": true,
+	"semanticTokenColors": {
+		"enumMember": {
+			"foreground": "#56b6c2"
+		},
+		"variable.constant": {
+			"foreground": "#d19a66"
+		},
+		"variable.defaultLibrary": {
+			"foreground": "#e5c07b"
+		}
+	},
+	"tokenColors": [
+		{
+			"name": "unison punctuation",
+			"scope": "punctuation.definition.delayed.unison,punctuation.definition.list.begin.unison,punctuation.definition.list.end.unison,punctuation.definition.ability.begin.unison,punctuation.definition.ability.end.unison,punctuation.operator.assignment.as.unison,punctuation.separator.pipe.unison,punctuation.separator.delimiter.unison,punctuation.definition.hash.unison",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "haskell variable generic-type",
+			"scope": "variable.other.generic-type.haskell",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "haskell storage type",
+			"scope": "storage.type.haskell",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "support.variable.magic.python",
+			"scope": "support.variable.magic.python",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "punctuation.separator.parameters.python",
+			"scope": "punctuation.separator.period.python,punctuation.separator.element.python,punctuation.parenthesis.begin.python,punctuation.parenthesis.end.python",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "variable.parameter.function.language.special.self.python",
+			"scope": "variable.parameter.function.language.special.self.python",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "storage.modifier.lifetime.rust",
+			"scope": "storage.modifier.lifetime.rust",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "support.function.std.rust",
+			"scope": "support.function.std.rust",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "entity.name.lifetime.rust",
+			"scope": "entity.name.lifetime.rust",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "variable.language.rust",
+			"scope": "variable.language.rust",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "support.constant.edge",
+			"scope": "support.constant.edge",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "regexp constant character-class",
+			"scope": "constant.other.character-class.regexp",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "regexp operator.quantifier",
+			"scope": "keyword.operator.quantifier.regexp",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "punctuation.definition",
+			"scope": "punctuation.definition.string.begin,punctuation.definition.string.end",
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "Text",
+			"scope": "variable.parameter.function",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Comment Markup Link",
+			"scope": "comment markup.link",
+			"settings": {
+				"foreground": "#5c6370"
+			}
+		},
+		{
+			"name": "markup diff",
+			"scope": "markup.changed.diff",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "diff",
+			"scope": "meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "inserted.diff",
+			"scope": "markup.inserted.diff",
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "deleted.diff",
+			"scope": "markup.deleted.diff",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "c++ function",
+			"scope": "meta.function.c,meta.function.cpp",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "c++ block",
+			"scope": "punctuation.section.block.begin.bracket.curly.cpp,punctuation.section.block.end.bracket.curly.cpp,punctuation.terminator.statement.c,punctuation.section.block.begin.bracket.curly.c,punctuation.section.block.end.bracket.curly.c,punctuation.section.parens.begin.bracket.round.c,punctuation.section.parens.end.bracket.round.c,punctuation.section.parameters.begin.bracket.round.c,punctuation.section.parameters.end.bracket.round.c",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "js/ts punctuation separator key-value",
+			"scope": "punctuation.separator.key-value",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "js/ts import keyword",
+			"scope": "keyword.operator.expression.import",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "math js/ts",
+			"scope": "support.constant.math",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "math property js/ts",
+			"scope": "support.constant.property.math",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "js/ts variable.other.constant",
+			"scope": "variable.other.constant",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "java type",
+			"scope": [
+				"storage.type.annotation.java",
+				"storage.type.object.array.java"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "java source",
+			"scope": "source.java",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "java modifier.import",
+			"scope": "punctuation.section.block.begin.java,punctuation.section.block.end.java,punctuation.definition.method-parameters.begin.java,punctuation.definition.method-parameters.end.java,meta.method.identifier.java,punctuation.section.method.begin.java,punctuation.section.method.end.java,punctuation.terminator.java,punctuation.section.class.begin.java,punctuation.section.class.end.java,punctuation.section.inner-class.begin.java,punctuation.section.inner-class.end.java,meta.method-call.java,punctuation.section.class.begin.bracket.curly.java,punctuation.section.class.end.bracket.curly.java,punctuation.section.method.begin.bracket.curly.java,punctuation.section.method.end.bracket.curly.java,punctuation.separator.period.java,punctuation.bracket.angle.java,punctuation.definition.annotation.java,meta.method.body.java",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "java modifier.import",
+			"scope": "meta.method.java",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "java modifier.import",
+			"scope": "storage.modifier.import.java,storage.type.java,storage.type.generic.java",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "java instanceof",
+			"scope": "keyword.operator.instanceof.java",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "java variable.name",
+			"scope": "meta.definition.variable.name.java",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "operator logical",
+			"scope": "keyword.operator.logical",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "operator bitwise",
+			"scope": "keyword.operator.bitwise",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "operator channel",
+			"scope": "keyword.operator.channel",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "support.constant.property-value.scss",
+			"scope": "support.constant.property-value.scss,support.constant.property-value.css",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "CSS/SCSS/LESS Operators",
+			"scope": "keyword.operator.css,keyword.operator.scss,keyword.operator.less",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "css color standard name",
+			"scope": "support.constant.color.w3c-standard-color-name.css,support.constant.color.w3c-standard-color-name.scss",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "css comma",
+			"scope": "punctuation.separator.list.comma.css",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "css attribute-name.id",
+			"scope": "support.constant.color.w3c-standard-color-name.css",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "css property-name",
+			"scope": "support.type.vendored.property-name.css",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "js/ts module",
+			"scope": "support.module.node,support.type.object.module,support.module.node",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "entity.name.type.module",
+			"scope": "entity.name.type.module",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "js variable readwrite",
+			"scope": "variable.other.readwrite,meta.object-literal.key,support.variable.property,support.variable.object.process,support.variable.object.node",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "js/ts json",
+			"scope": "support.constant.json",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "js/ts Keyword",
+			"scope": [
+				"keyword.operator.expression.instanceof",
+				"keyword.operator.new",
+				"keyword.operator.ternary",
+				"keyword.operator.optional",
+				"keyword.operator.expression.keyof"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "js/ts console",
+			"scope": "support.type.object.console",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "js/ts support.variable.property.process",
+			"scope": "support.variable.property.process",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "js console function",
+			"scope": "entity.name.function,support.function.console",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "keyword.operator.misc.rust",
+			"scope": "keyword.operator.misc.rust",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "operator",
+			"scope": "keyword.operator.delete",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "js dom",
+			"scope": "support.type.object.dom",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "js dom variable",
+			"scope": "support.variable.dom,support.variable.property.dom",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "keyword.operator",
+			"scope": "keyword.operator.arithmetic,keyword.operator.comparison,keyword.operator.decrement,keyword.operator.increment,keyword.operator.relational",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "C operator assignment",
+			"scope": "keyword.operator.assignment.c,keyword.operator.comparison.c,keyword.operator.c,keyword.operator.increment.c,keyword.operator.decrement.c,keyword.operator.bitwise.shift.c,keyword.operator.assignment.cpp,keyword.operator.comparison.cpp,keyword.operator.cpp,keyword.operator.increment.cpp,keyword.operator.decrement.cpp,keyword.operator.bitwise.shift.cpp",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Punctuation",
+			"scope": "punctuation.separator.delimiter",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Other punctuation .c",
+			"scope": "punctuation.separator.c,punctuation.separator.cpp",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "C type posix-reserved",
+			"scope": "support.type.posix-reserved.c,support.type.posix-reserved.cpp",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "keyword.operator.sizeof.c",
+			"scope": "keyword.operator.sizeof.c,keyword.operator.sizeof.cpp",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "python parameter",
+			"scope": "variable.parameter.function.language.python",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "python type",
+			"scope": "support.type.python",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "python logical",
+			"scope": "keyword.operator.logical.python",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "pyCs",
+			"scope": "variable.parameter.function.python",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "python block",
+			"scope": "punctuation.definition.arguments.begin.python,punctuation.definition.arguments.end.python,punctuation.separator.arguments.python,punctuation.definition.list.begin.python,punctuation.definition.list.end.python",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "python function-call.generic",
+			"scope": "meta.function-call.generic.python",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "python placeholder reset to normal string",
+			"scope": "constant.character.format.placeholder.other.python",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Operators",
+			"scope": "keyword.operator",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Compound Assignment Operators",
+			"scope": "keyword.operator.assignment.compound",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Keywords",
+			"scope": "keyword",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Variables",
+			"scope": "variable",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Variables",
+			"scope": "variable.c",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Language variables",
+			"scope": "variable.language",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Java Variables",
+			"scope": "token.variable.parameter.java",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Java Imports",
+			"scope": "import.storage.java",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Packages",
+			"scope": "token.package.keyword",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Packages",
+			"scope": "token.package",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Functions",
+			"scope": [
+				"entity.name.function",
+				"meta.require",
+				"support.function.any-method",
+				"variable.function"
+			],
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "Classes",
+			"scope": "entity.name.type.namespace",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Classes",
+			"scope": "support.class, entity.name.type.class",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Class name",
+			"scope": "entity.name.class.identifier.namespace.type",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Class name",
+			"scope": [
+				"entity.name.class",
+				"variable.other.class.js",
+				"variable.other.class.ts"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Class name php",
+			"scope": "variable.other.class.php",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Type Name",
+			"scope": "entity.name.type",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Keyword Control",
+			"scope": "keyword.control",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Control Elements",
+			"scope": "control.elements, keyword.operator.less",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Methods",
+			"scope": "keyword.other.special-method",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "Storage",
+			"scope": "storage",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Storage JS TS",
+			"scope": "token.storage",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Source Js Keyword Operator Delete,source Js Keyword Operator In,source Js Keyword Operator Of,source Js Keyword Operator Instanceof,source Js Keyword Operator New,source Js Keyword Operator Typeof,source Js Keyword Operator Void",
+			"scope": "keyword.operator.expression.delete,keyword.operator.expression.in,keyword.operator.expression.of,keyword.operator.expression.instanceof,keyword.operator.new,keyword.operator.expression.typeof,keyword.operator.expression.void",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Java Storage",
+			"scope": "token.storage.type.java",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Support",
+			"scope": "support.function",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "Support type",
+			"scope": "support.type.property-name",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Support type",
+			"scope": "support.constant.property-value",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Support type",
+			"scope": "support.constant.font-name",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Meta tag",
+			"scope": "meta.tag",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Strings",
+			"scope": "string",
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "Inherited Class",
+			"scope": "entity.other.inherited-class",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Constant other symbol",
+			"scope": "constant.other.symbol",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "Integers",
+			"scope": "constant.numeric",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Constants",
+			"scope": "constant",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Constants",
+			"scope": "punctuation.definition.constant",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Tags",
+			"scope": "entity.name.tag",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Attributes",
+			"scope": "entity.other.attribute-name",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Attribute IDs",
+			"scope": "entity.other.attribute-name.id",
+			"settings": {
+				"fontStyle": "normal",
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "Attribute class",
+			"scope": "entity.other.attribute-name.class.css",
+			"settings": {
+				"fontStyle": "normal",
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Selector",
+			"scope": "meta.selector",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Headings",
+			"scope": "markup.heading",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Headings",
+			"scope": "markup.heading punctuation.definition.heading, entity.name.section",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "Units",
+			"scope": "keyword.other.unit",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Bold",
+			"scope": "markup.bold,todo.bold",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "Bold",
+			"scope": "punctuation.definition.bold",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "markup Italic",
+			"scope": "markup.italic, punctuation.definition.italic,todo.emphasis",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "emphasis md",
+			"scope": "emphasis md",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown headings",
+			"scope": "entity.name.section.markdown",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown heading Punctuation Definition",
+			"scope": "punctuation.definition.heading.markdown",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "punctuation.definition.list.begin.markdown",
+			"scope": "punctuation.definition.list.begin.markdown",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown heading setext",
+			"scope": "markup.heading.setext",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Bold",
+			"scope": "punctuation.definition.bold.markdown",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+			"scope": "markup.inline.raw.markdown",
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Inline Raw",
+			"scope": "markup.inline.raw.string.markdown",
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
+			"scope": "punctuation.definition.list.markdown",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Punctuation Definition String",
+			"scope": [
+				"punctuation.definition.string.begin.markdown",
+				"punctuation.definition.string.end.markdown",
+				"punctuation.definition.metadata.markdown"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "beginning.punctuation.definition.list.markdown",
+			"scope": [
+				"beginning.punctuation.definition.list.markdown"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Punctuation Definition Link",
+			"scope": "punctuation.definition.metadata.markdown",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Underline Link/Image",
+			"scope": "markup.underline.link.markdown,markup.underline.link.image.markdown",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Link Title/Description",
+			"scope": "string.other.link.title.markdown,string.other.link.description.markdown",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "Regular Expressions",
+			"scope": "string.regexp",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "Escape Characters",
+			"scope": "constant.character.escape",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "Embedded",
+			"scope": "punctuation.section.embedded, variable.interpolation",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Embedded",
+			"scope": "punctuation.section.embedded.begin,punctuation.section.embedded.end",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "illegal",
+			"scope": "invalid.illegal",
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
+			"name": "illegal",
+			"scope": "invalid.illegal.bad-ampersand.html",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Broken",
+			"scope": "invalid.broken",
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
+			"name": "Deprecated",
+			"scope": "invalid.deprecated",
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
+			"name": "Unimplemented",
+			"scope": "invalid.unimplemented",
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
+			"name": "Source Json Meta Structure Dictionary Json > String Quoted Json",
+			"scope": "source.json meta.structure.dictionary.json > string.quoted.json",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Source Json Meta Structure Dictionary Json > String Quoted Json > Punctuation String",
+			"scope": "source.json meta.structure.dictionary.json > string.quoted.json > punctuation.string",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Source Json Meta Structure Dictionary Json > Value Json > String Quoted Json,source Json Meta Structure Array Json > Value Json > String Quoted Json,source Json Meta Structure Dictionary Json > Value Json > String Quoted Json > Punctuation,source Json Meta Structure Array Json > Value Json > String Quoted Json > Punctuation",
+			"scope": "source.json meta.structure.dictionary.json > value.json > string.quoted.json,source.json meta.structure.array.json > value.json > string.quoted.json,source.json meta.structure.dictionary.json > value.json > string.quoted.json > punctuation,source.json meta.structure.array.json > value.json > string.quoted.json > punctuation",
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "Source Json Meta Structure Dictionary Json > Constant Language Json,source Json Meta Structure Array Json > Constant Language Json",
+			"scope": "source.json meta.structure.dictionary.json > constant.language.json,source.json meta.structure.array.json > constant.language.json",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] JSON Property Name",
+			"scope": "support.type.property-name.json",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] JSON Punctuation for Property Name",
+			"scope": "support.type.property-name.json punctuation",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "laravel blade tag",
+			"scope": "text.html.laravel-blade source.php.embedded.line.html entity.name.tag.laravel-blade",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "laravel blade @",
+			"scope": "text.html.laravel-blade source.php.embedded.line.html support.constant.laravel-blade",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "use statement for other classes",
+			"scope": "support.other.namespace.use.php,support.other.namespace.use-as.php,support.other.namespace.php,entity.other.alias.php,meta.interface.php",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "error suppression",
+			"scope": "keyword.operator.error-control.php",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "php instanceof",
+			"scope": "keyword.operator.type.php",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "style double quoted array index normal begin",
+			"scope": "punctuation.section.array.begin.php",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "style double quoted array index normal end",
+			"scope": "punctuation.section.array.end.php",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "php illegal.non-null-typehinted",
+			"scope": "invalid.illegal.non-null-typehinted.php",
+			"settings": {
+				"foreground": "#f44747"
+			}
+		},
+		{
+			"name": "php types",
+			"scope": "storage.type.php,meta.other.type.phpdoc.php,keyword.other.type.php,keyword.other.array.phpdoc.php",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "php call-function",
+			"scope": "meta.function-call.php,meta.function-call.object.php,meta.function-call.static.php",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "php function-resets",
+			"scope": "punctuation.definition.parameters.begin.bracket.round.php,punctuation.definition.parameters.end.bracket.round.php,punctuation.separator.delimiter.php,punctuation.section.scope.begin.php,punctuation.section.scope.end.php,punctuation.terminator.expression.php,punctuation.definition.arguments.begin.bracket.round.php,punctuation.definition.arguments.end.bracket.round.php,punctuation.definition.storage-type.begin.bracket.round.php,punctuation.definition.storage-type.end.bracket.round.php,punctuation.definition.array.begin.bracket.round.php,punctuation.definition.array.end.bracket.round.php,punctuation.definition.begin.bracket.round.php,punctuation.definition.end.bracket.round.php,punctuation.definition.begin.bracket.curly.php,punctuation.definition.end.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php,punctuation.definition.section.switch-block.start.bracket.curly.php,punctuation.definition.section.switch-block.begin.bracket.curly.php,punctuation.definition.section.switch-block.end.bracket.curly.php",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "support php constants",
+			"scope": "support.constant.core.rust",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "support php constants",
+			"scope": "support.constant.ext.php,support.constant.std.php,support.constant.core.php,support.constant.parser-token.php",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "php goto",
+			"scope": "entity.name.goto-label.php,support.other.php",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "php logical/bitwise operator",
+			"scope": "keyword.operator.logical.php,keyword.operator.bitwise.php,keyword.operator.arithmetic.php",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "php regexp operator",
+			"scope": "keyword.operator.regexp.php",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "php comparison",
+			"scope": "keyword.operator.comparison.php",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "php heredoc/nowdoc",
+			"scope": "keyword.operator.heredoc.php,keyword.operator.nowdoc.php",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "python function decorator @",
+			"scope": "meta.function.decorator.python",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "python function support",
+			"scope": "support.token.decorator.python,meta.function.decorator.identifier.python",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "parameter function js/ts",
+			"scope": "function.parameter",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "brace function",
+			"scope": "function.brace",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "parameter function ruby cs",
+			"scope": "function.parameter.ruby, function.parameter.cs",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "constant.language.symbol.ruby",
+			"scope": "constant.language.symbol.ruby",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "rgb-value",
+			"scope": "rgb-value",
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "rgb value",
+			"scope": "inline-color-decoration rgb-value",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "rgb value less",
+			"scope": "less rgb-value",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "sass selector",
+			"scope": "selector.sass",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "ts primitive/builtin types",
+			"scope": "support.type.primitive.ts,support.type.builtin.ts,support.type.primitive.tsx,support.type.builtin.tsx",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "block scope",
+			"scope": "block.scope.end,block.scope.begin",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "cs storage type",
+			"scope": "storage.type.cs",
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "cs local variable",
+			"scope": "entity.name.variable.local.cs",
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"scope": "token.info-token",
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"scope": "token.warn-token",
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"scope": "token.error-token",
+			"settings": {
+				"foreground": "#f44747"
+			}
+		},
+		{
+			"scope": "token.debug-token",
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "String interpolation",
+			"scope": [
+				"punctuation.definition.template-expression.begin",
+				"punctuation.definition.template-expression.end",
+				"punctuation.section.embedded"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "Reset JavaScript string interpolation expression",
+			"scope": [
+				"meta.template.expression"
+			],
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Import module JS",
+			"scope": [
+				"keyword.operator.module"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "js Flowtype",
+			"scope": [
+				"support.type.type.flowtype"
+			],
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "js Flow",
+			"scope": [
+				"support.type.primitive"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "js class prop",
+			"scope": [
+				"meta.property.object"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "js func parameter",
+			"scope": [
+				"variable.parameter.function.js"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "js template literals begin",
+			"scope": [
+				"keyword.other.template.begin"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "js template literals end",
+			"scope": [
+				"keyword.other.template.end"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "js template literals variable braces begin",
+			"scope": [
+				"keyword.other.substitution.begin"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "js template literals variable braces end",
+			"scope": [
+				"keyword.other.substitution.end"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "js operator.assignment",
+			"scope": [
+				"keyword.operator.assignment"
+			],
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "go operator",
+			"scope": [
+				"keyword.operator.assignment.go",
+				"keyword.operator.address.go"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Go package name",
+			"scope": [
+				"entity.name.package.go"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "elm prelude",
+			"scope": [
+				"support.type.prelude.elm"
+			],
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "elm constant",
+			"scope": [
+				"support.constant.elm"
+			],
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "template literal",
+			"scope": [
+				"punctuation.quasi.element"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "html/pug (jade) escaped characters and entities",
+			"scope": [
+				"constant.character.entity"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "styling css pseudo-elements/classes to be able to differentiate from classes which are the same colour",
+			"scope": [
+				"entity.other.attribute-name.pseudo-element",
+				"entity.other.attribute-name.pseudo-class"
+			],
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "Clojure globals",
+			"scope": [
+				"entity.global.clojure"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Clojure symbols",
+			"scope": [
+				"meta.symbol.clojure"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Clojure constants",
+			"scope": [
+				"constant.keyword.clojure"
+			],
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "CoffeeScript Function Argument",
+			"scope": [
+				"meta.arguments.coffee",
+				"variable.parameter.function.coffee"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Ini Default Text",
+			"scope": [
+				"source.ini"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "Makefile prerequisities",
+			"scope": [
+				"meta.scope.prerequisites.makefile"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Makefile text colour",
+			"scope": [
+				"source.makefile"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Groovy import names",
+			"scope": [
+				"storage.modifier.import.groovy"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Groovy Methods",
+			"scope": [
+				"meta.method.groovy"
+			],
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "Groovy Variables",
+			"scope": [
+				"meta.definition.variable.name.groovy"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "Groovy Inheritance",
+			"scope": [
+				"meta.definition.class.inherited.classes.groovy"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "HLSL Semantic",
+			"scope": [
+				"support.variable.semantic.hlsl"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "HLSL Types",
+			"scope": [
+				"support.type.texture.hlsl",
+				"support.type.sampler.hlsl",
+				"support.type.object.hlsl",
+				"support.type.object.rw.hlsl",
+				"support.type.fx.hlsl",
+				"support.type.object.hlsl"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "SQL Variables",
+			"scope": [
+				"text.variable",
+				"text.bracketed"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "types",
+			"scope": [
+				"support.type.swift",
+				"support.type.vb.asp"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "heading 1, keyword",
+			"scope": [
+				"entity.name.function.xi"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "heading 2, callable",
+			"scope": [
+				"entity.name.class.xi"
+			],
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "heading 3, property",
+			"scope": [
+				"constant.character.character-class.regexp.xi"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "heading 4, type, class, interface",
+			"scope": [
+				"constant.regexp.xi"
+			],
+			"settings": {
+				"foreground": "#c678dd"
+			}
+		},
+		{
+			"name": "heading 5, enums, preprocessor, constant, decorator",
+			"scope": [
+				"keyword.control.xi"
+			],
+			"settings": {
+				"foreground": "#56b6c2"
+			}
+		},
+		{
+			"name": "heading 6, number",
+			"scope": [
+				"invalid.xi"
+			],
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "string",
+			"scope": [
+				"beginning.punctuation.definition.quote.markdown.xi"
+			],
+			"settings": {
+				"foreground": "#98c379"
+			}
+		},
+		{
+			"name": "comments",
+			"scope": [
+				"beginning.punctuation.definition.list.markdown.xi"
+			],
+			"settings": {
+				"foreground": "#7f848e"
+			}
+		},
+		{
+			"name": "link",
+			"scope": [
+				"constant.character.xi"
+			],
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "accent",
+			"scope": [
+				"accent.xi"
+			],
+			"settings": {
+				"foreground": "#61afef"
+			}
+		},
+		{
+			"name": "wikiword",
+			"scope": [
+				"wikiword.xi"
+			],
+			"settings": {
+				"foreground": "#d19a66"
+			}
+		},
+		{
+			"name": "language operators like '+', '-' etc",
+			"scope": [
+				"constant.other.color.rgb-value.xi"
+			],
+			"settings": {
+				"foreground": "#ffffff"
+			}
+		},
+		{
+			"name": "elements to dim",
+			"scope": [
+				"punctuation.definition.tag.xi"
+			],
+			"settings": {
+				"foreground": "#5c6370"
+			}
+		},
+		{
+			"name": "C++/C#",
+			"scope": [
+				"entity.name.label.cs",
+				"entity.name.scope-resolution.function.call",
+				"entity.name.scope-resolution.function.definition"
+			],
+			"settings": {
+				"foreground": "#e5c07b"
+			}
+		},
+		{
+			"name": "Markdown underscore-style headers",
+			"scope": [
+				"entity.name.label.cs",
+				"markup.heading.setext.1.markdown",
+				"markup.heading.setext.2.markdown"
+			],
+			"settings": {
+				"foreground": "#e06c75"
+			}
+		},
+		{
+			"name": "meta.brace.square",
+			"scope": [
+				" meta.brace.square"
+			],
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "Comments",
+			"scope": "comment, punctuation.definition.comment",
+			"settings": {
+				"fontStyle": "italic",
+				"foreground": "#7f848e"
+			}
+		},
+		{
+			"name": "[VSCODE-CUSTOM] Markdown Quote",
+			"scope": "markup.quote.markdown",
+			"settings": {
+				"foreground": "#5c6370"
+			}
+		},
+		{
+			"name": "punctuation.definition.block.sequence.item.yaml",
+			"scope": "punctuation.definition.block.sequence.item.yaml",
+			"settings": {
+				"foreground": "#abb2bf"
+			}
+		},
+		{
+			"name": "js/ts italic",
+			"scope": "entity.other.attribute-name.js,entity.other.attribute-name.ts,entity.other.attribute-name.jsx,entity.other.attribute-name.tsx,variable.parameter,variable.language.super",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "comment",
+			"scope": "comment.line.double-slash,comment.block.documentation",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "Python Keyword Control",
+			"scope": "keyword.control.import.python,keyword.control.flow.python",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		},
+		{
+			"name": "markup.italic.markdown",
+			"scope": "markup.italic.markdown",
+			"settings": {
+				"fontStyle": "italic"
+			}
+		}
+	],
+	"colors": {
+		"activityBar.background": "#282c34",
+		"activityBar.foreground": "#d7dae0",
+		"activityBarBadge.background": "#4d78cc",
+		"activityBarBadge.foreground": "#f8fafd",
+		"badge.background": "#282c34",
+		"button.background": "#404754",
+		"debugToolBar.background": "#21252b",
+		"diffEditor.insertedTextBackground": "#00809b33",
+		"dropdown.background": "#21252b",
+		"dropdown.border": "#21252b",
+		"editor.background": "#282c34",
+		"editor.findMatchBackground": "#42557b",
+		"editor.findMatchBorder": "#457dff",
+		"editor.findMatchHighlightBackground": "#6199ff2f",
+		"editor.foreground": "#abb2bf",
+		"editor.lineHighlightBackground": "#2c313c",
+		"editor.selectionBackground": "#67769660",
+		"editor.selectionHighlightBackground": "#ffffff10",
+		"editor.selectionHighlightBorder": "#dddddd",
+		"editor.wordHighlightBackground": "#d2e0ff2f",
+		"editor.wordHighlightBorder": "#7f848e",
+		"editor.wordHighlightStrongBackground": "#abb2bf26",
+		"editor.wordHighlightStrongBorder": "#7f848e",
+		"editorActiveLineNumber.foreground": "#737984",
+		"editorBracketMatch.background": "#515a6b",
+		"editorBracketMatch.border": "#515a6b",
+		"editorCursor.background": "#ffffffc9",
+		"editorCursor.foreground": "#528bff",
+		"editorError.foreground": "#c24038",
+		"editorGroup.background": "#181a1f",
+		"editorGroup.border": "#181a1f",
+		"editorGroupHeader.tabsBackground": "#21252b",
+		"editorHoverWidget.background": "#21252b",
+		"editorHoverWidget.border": "#181a1f",
+		"editorIndentGuide.activeBackground": "#c8c8c859",
+		"editorIndentGuide.background": "#3b4048",
+		"editorLineNumber.foreground": "#495162",
+		"editorMarkerNavigation.background": "#21252b",
+		"editorRuler.foreground": "#abb2bf26",
+		"editorSuggestWidget.background": "#21252b",
+		"editorSuggestWidget.border": "#181a1f",
+		"editorSuggestWidget.selectedBackground": "#2c313a",
+		"editorWarning.foreground": "#d19a66",
+		"editorWhitespace.foreground": "#3b4048",
+		"editorWidget.background": "#21252b",
+		"focusBorder": "#464646",
+		"input.background": "#1d1f23",
+		"list.activeSelectionBackground": "#2c313a",
+		"list.activeSelectionForeground": "#d7dae0",
+		"list.focusBackground": "#383e4a",
+		"list.highlightForeground": "#c5c5c5",
+		"list.hoverBackground": "#292d35",
+		"list.inactiveSelectionBackground": "#2c313a",
+		"list.inactiveSelectionForeground": "#d7dae0",
+		"list.warningForeground": "#d19a66",
+		"menu.foreground": "#c8c8c8",
+		"panelSectionHeader.background": "#21252b",
+		"peekViewEditor.background": "#1b1d23",
+		"peekViewEditor.matchHighlightBackground": "#29244b",
+		"peekViewResult.background": "#22262b",
+		"scrollbarSlider.activeBackground": "#747d9180",
+		"scrollbarSlider.background": "#4e566660",
+		"scrollbarSlider.hoverBackground": "#5a637580",
+		"sideBar.background": "#21252b",
+		"sideBarSectionHeader.background": "#282c34",
+		"statusBar.background": "#21252b",
+		"statusBar.debuggingBackground": "#cc6633",
+		"statusBar.debuggingBorder": "#66017a",
+		"statusBar.debuggingForeground": "#ffffff",
+		"statusBar.foreground": "#9da5b4",
+		"statusBar.noFolderBackground": "#21252b",
+		"statusBarItem.hoverBackground": "#2c313a",
+		"statusBarItem.remoteBackground": "#4d78cc",
+		"statusBarItem.remoteForeground": "#f8fafd",
+		"tab.activeBackground": "#282c34",
+		"tab.activeForeground": "#dcdcdc",
+		"tab.border": "#181a1f",
+		"tab.hoverBackground": "#323842",
+		"tab.inactiveBackground": "#21252b",
+		"tab.unfocusedHoverBackground": "#323842",
+		"terminal.ansiBlack": "#3f4451",
+		"terminal.ansiBlue": "#4aa5f0",
+		"terminal.ansiBrightBlack": "#4f5666",
+		"terminal.ansiBrightBlue": "#4dc4ff",
+		"terminal.ansiBrightCyan": "#4cd1e0",
+		"terminal.ansiBrightGreen": "#a5e075",
+		"terminal.ansiBrightMagenta": "#de73ff",
+		"terminal.ansiBrightRed": "#ff616e",
+		"terminal.ansiBrightWhite": "#d7dae0",
+		"terminal.ansiBrightYellow": "#f0a45d",
+		"terminal.ansiCyan": "#42b3c2",
+		"terminal.ansiGreen": "#8cc265",
+		"terminal.ansiMagenta": "#c162de",
+		"terminal.ansiRed": "#e05561",
+		"terminal.ansiWhite": "#e6e6e6",
+		"terminal.ansiYellow": "#d18f52",
+		"terminal.background": "#282c34",
+		"terminal.border": "#abb2bf",
+		"terminal.foreground": "#abb2bf",
+		"terminal.selectionBackground": "#abb2bf30",
+		"textLink.foreground": "#61afef",
+		"titleBar.activeBackground": "#282c34",
+		"titleBar.activeForeground": "#9da5b4",
+		"titleBar.inactiveBackground": "#21252b",
+		"titleBar.inactiveForeground": "#6b717d"
+	}
+}

--- a/packages/@romejs/string-markup/types.ts
+++ b/packages/@romejs/string-markup/types.ts
@@ -8,6 +8,7 @@
 import {BaseTokens, SimpleToken, ValueToken} from "@romejs/parser-core";
 import {Dict} from "@romejs/typescript-helpers";
 import {AbsoluteFilePath} from "@romejs/path";
+import {UserConfig} from "@romejs/core/common/userConfig";
 
 export type Tokens = BaseTokens & {
 	Text: ValueToken<"Text", string>;
@@ -39,6 +40,7 @@ export type ChildNode = TextNode | TagNode;
 export type Children = Array<ChildNode>;
 
 export type MarkupTagName =
+	| "token"
 	| "hr"
 	| "pad"
 	| "grammarNumber"
@@ -75,6 +77,7 @@ export type MarkupFormatFilenameHumanizer = (
 ) => undefined | string;
 
 export type MarkupFormatOptions = {
+	userConfig?: UserConfig;
 	normalizeFilename?: MarkupFormatFilenameNormalizer;
 	humanizeFilename?: MarkupFormatFilenameHumanizer;
 	cwd?: AbsoluteFilePath;
@@ -92,3 +95,34 @@ export type MarkupLinesAndWidth = {
 	width: number;
 	lines: Array<string>;
 };
+
+export type GridOutputFormat = "ansi" | "html" | "none";
+
+export type MarkupTokenType =
+	| "keyword"
+	| "number"
+	| "regex"
+	| "string"
+	| "comment"
+	| "operator"
+	| "punctuation"
+	| "variable"
+	| "attr-name";
+
+export type MarkupColor =
+	| "black"
+	| "brightBlack"
+	| "red"
+	| "brightRed"
+	| "green"
+	| "brightGreen"
+	| "yellow"
+	| "brightYellow"
+	| "blue"
+	| "brightBlue"
+	| "magenta"
+	| "brightMagenta"
+	| "cyan"
+	| "brightCyan"
+	| "white"
+	| "brightWhite";

--- a/website/src/_includes/homepage-screenshot.md
+++ b/website/src/_includes/homepage-screenshot.md
@@ -1,0 +1,47 @@
+<pre class="language-text homepage-example collapsed"><code class="language-text"><span style="color: CornflowerBlue">$</span> rome check
+
+ <span style="text-decoration-style: dotted;">src/App.js:2:7</span> <strong>lint/js/noUnusedVariables</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">The import variable </span><span style="color: Tomato;"><strong>logo</strong></span><span style="color: Tomato;"> is unused.</span>
+
+  <strong>  1 │ </strong><span class="token comment">// @jsx</span>
+  <strong><span style="color: Tomato;">&gt;</span></strong><strong> 2 │ </strong><span class="token keyword">import</span> <span class="token variable">logo</span> <span class="token keyword">from</span> <span class="token string">&quot;./logo.svg&quot;</span><span class="token punctuation">;</span>
+     <strong> │ </strong>       <span style="color: Tomato;"><strong>^^^^</strong></span>
+  <strong>  3 │ </strong><span class="token keyword">import</span> <span class="token string">&quot;./App.css&quot;</span><span class="token punctuation">;</span>
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Unused variables are dead code and usually the result of incomplete</span>
+    <span style="color: DodgerBlue;">refactoring.</span>
+
+ <span style="text-decoration-style: dotted;">src/App.js:8:8</span> <strong>lint/jsx-a11y/altText</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Provide </span><span style="color: Tomato;"><strong>alt</strong></span><span style="color: Tomato;"> text when using </span><span style="color: Tomato;"><strong>img</strong></span><span style="color: Tomato;">, </span><span style="color: Tomato;"><strong>area</strong></span><span style="color: Tomato;">, </span><span style="color: Tomato;"><strong>input type=&apos;image&apos;</strong></span><span style="color: Tomato;">, and </span><span style="color: Tomato;"><strong>object</strong></span>
+    <span style="color: Tomato;">elements.</span>
+
+   <strong>  6 │ </strong> <span class="token keyword">return</span> &lt;<span class="token variable">div</span> <span class="token attr-name">className</span><span class="token operator">=</span><span class="token string">&quot;App&quot;</span>&gt;
+   <strong>  7 │ </strong>      &lt;<span class="token variable">header</span> <span class="token attr-name">className</span><span class="token operator">=</span><span class="token string">&quot;App-header&quot;</span>&gt;
+   <strong><span style="color: Tomato;">&gt;</span></strong><strong> 8 │ </strong>        &lt;<span class="token variable">img</span> <span class="token attr-name">src</span><span class="token operator">=</span><span class="token punctuation">{</span><span class="token variable">logo2</span><span class="token punctuation">}</span> <span class="token attr-name">className</span><span class="token operator">=</span><span class="token string">&quot;App-logo&quot;</span> <span class="token operator">/</span>&gt;
+      <strong> │ </strong>        <span style="color: Tomato;"><strong>^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^</strong></span>
+   <strong>  9 │ </strong>        &lt;<span class="token variable">p</span>&gt;
+  <strong>  10 │ </strong>          Edit &lt;<span class="token variable">code</span>&gt;src/App.js&lt;<span class="token operator">/</span><span class="token variable">code</span>&gt; and save to reload.
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Meaningful alternative text on elements helps users relying on screen</span>
+    <span style="color: DodgerBlue;">readers to understand content&apos;s purpose within a page.</span>
+
+ <span style="text-decoration-style: dotted;">src/App.js:8:18</span> <strong>lint/js/undeclaredVariables</strong> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  <strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">The </span><span style="color: Tomato;"><strong>logo2</strong></span><span style="color: Tomato;"> variable is undeclared.</span>
+
+   <strong>  6 │ </strong> <span class="token keyword">return</span> &lt;<span class="token variable">div</span> <span class="token attr-name">className</span><span class="token operator">=</span><span class="token string">&quot;App&quot;</span>&gt;
+   <strong>  7 │ </strong>      &lt;<span class="token variable">header</span> <span class="token attr-name">className</span><span class="token operator">=</span><span class="token string">&quot;App-header&quot;</span>&gt;
+   <strong><span style="color: Tomato;">&gt;</span></strong><strong> 8 │ </strong>        &lt;<span class="token variable">img</span> <span class="token attr-name">src</span><span class="token operator">=</span><span class="token punctuation">{</span><span class="token variable">logo2</span><span class="token punctuation">}</span> <span class="token attr-name">className</span><span class="token operator">=</span><span class="token string">&quot;App-logo&quot;</span> <span class="token operator">/</span>&gt;
+      <strong> │ </strong>                  <span style="color: Tomato;"><strong>^^^^^</strong></span>
+   <strong>  9 │ </strong>        &lt;<span class="token variable">p</span>&gt;
+  <strong>  10 │ </strong>          Edit &lt;<span class="token variable">code</span>&gt;src/App.js&lt;<span class="token operator">/</span><span class="token variable">code</span>&gt; and save to reload.
+
+  <strong><span style="color: DodgerBlue;">ℹ </span></strong><span style="color: DodgerBlue;">Did you mean </span><span style="color: DodgerBlue;"><strong>logo</strong></span><span style="color: DodgerBlue;">?</span>
+
+  <span style="color: Tomato;">-</span> <span style="color: Tomato;">logo</span><span style="color: Tomato;"><strong>2</strong></span>
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+<strong><span style="color: Tomato;">✖ </span></strong><span style="color: Tomato;">Found </span><span style="color: Tomato;"><strong>3</strong></span><span style="color: Tomato;"> </span><span style="color: Tomato;">problems</span></code><div class="expand">Click to Expand</div></pre>

--- a/website/src/_includes/layouts/sections/head.njk
+++ b/website/src/_includes/layouts/sections/head.njk
@@ -13,8 +13,8 @@
 	<meta property="twitter:image" content="{{ config.twitter.image | url }}">
 	<meta name="twitter:image:alt" content="{{ config.twitter.imageAlt }}">
 	<meta name="twitter:card" content="{{ config.twitter.card }}">
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.20.0/themes/prism-tomorrow.min.css">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&display=swap">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;700&display=swap">
 	<link rel="stylesheet" href="{{ '/static/styles.css' | url }}">
 	<script>
 

--- a/website/src/index.md
+++ b/website/src/index.md
@@ -13,6 +13,10 @@ There is value in these being a single tool. Building upon a shared base allows 
 
 **Rome** is maintained by a [team of contributors](/contributing/team). **Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
 
+## Preview
+
+{% rootmd "website/src/_includes/homepage-screenshot.md" %}
+
 ## Development status
 
 **Rome is currently only supported as a [linter](/docs/lint).** As Rome's use as a linter stabilizes we will begin polishing the other components for release and usage.
@@ -30,19 +34,6 @@ Rome aims to have the following responsibilities:
  - Type Checking
 
 ## Learn more
-
-
-<div class="image-horizontal-overflow" >
-	<div class="image-scroll" >
-		<img  src="/static/img/screenshots/1.png" alt="Rome Lint Sample - alt missing" />
-	</div>
-</div>
-
-<div class="image-horizontal-overflow" >
-	<div class="image-scroll" >
-		<img  src="/static/img/screenshots/2.png" alt="Rome Lint Sample - variable undeclared/unused" />
-	</div>
-</div>
 
 <ul class="home-actions">
 	<li>

--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -27,7 +27,8 @@ body {
 }
 
 code {
-  font-family: monospace;
+  font-family: "Fira Code", monospace !important;
+  tab-size: 2 !important;
   background-color: rgba(0, 0, 0, 0.08);
   padding: 5px;
 }

--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -4,11 +4,9 @@ html {
 }
 
 html {
-
   @include transition-timing;
   transition-property: background;
   background: var(--background-color);
-
 }
 
 body {
@@ -21,6 +19,7 @@ body {
   color: var(--font-color);
   line-height: 1.5;
   margin: 0;
+
   @include desktop-only() {
     border-top: $unit / 3 solid var(--top-border-color);
   }
@@ -84,7 +83,7 @@ a:active {
   overflow: hidden;
 }
 
-.overlay{
+.overlay {
   transform: translateX(100%);
   width: 100%;
   height: 100%;
@@ -164,19 +163,25 @@ a:active {
 }
 
 .icon {
+  .path-1, .path-2 {
+    fill: var(--logo-font-color);
+  }
 
-    .path-1, .path-2 {
-      fill: var(--logo-font-color);
+  .path-2 {
+    opacity: 0.7;
+  }
+
+  &:active{
+    .path-1, .path-2{
+      fill: var(--primary-color);
     }
+  }
+}
 
-    .path-2 {
-      opacity: 0.7;
-    }
-
-    &:active{
-      .path-1, .path-2{
-        fill: var(--primary-color);
-      }
-    }
-
+pre[class*=language-] {
+  @include mobile-only() {
+    border-radius: 0 !important;
+    margin-left: -32px;
+    margin-right: -32px;
+  }
 }

--- a/website/src/styles/_homepage.scss
+++ b/website/src/styles/_homepage.scss
@@ -33,12 +33,12 @@ ul.home-actions {
     flex-direction: column;
   }
 
-  svg{
+  svg {
     width: 40px;
     height: 40px;
   }
 
-  a.getting-started{
+  a.getting-started {
     border: var(--logo-font-color) 4px solid;
     border-radius: 60px;
     padding: 12px 32px;
@@ -50,7 +50,7 @@ ul.home-actions {
     display: inline;
   }
 
-  a.getting-started:before{
+  a.getting-started:before {
     content: " ";
     position: absolute;
     z-index: -1;
@@ -63,24 +63,18 @@ ul.home-actions {
   }
 
   //align text to icon
-  a{
+  a {
     display: flex;
     align-items: center;
     justify-content: center;
   }
 
-  svg{
-    margin-right: 16px;
-  }
-
-  svg{
+  svg {
     margin-right: 16px;
   }
 
   &:last-child{
-
     margin-bottom: 0;
-
   }
 
   li {
@@ -100,11 +94,35 @@ ul.home-actions {
   }
 }
 
-.image-horizontal-overflow {
-  overflow-x:auto;
-}
-.image-scroll{
-  display: inline;
-  white-space: nowrap;
-}
+pre.homepage-example {
+  position: relative;
+  transition: all 200ms ease-in-out;
 
+  &.collapsed {
+    height: 300px;
+    overflow: hidden;
+    box-shadow: inset 0 -10px 50px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+
+    .expand {
+      display: block;
+    }
+  }
+
+  .expand {
+    display: none;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-weight: bold;
+    line-height: 40px;
+    color: #fff;
+    font-family: inherit;
+  }
+
+  code {
+    line-height: 0;
+  }
+}

--- a/website/src/styles/_prism.scss
+++ b/website/src/styles/_prism.scss
@@ -1,0 +1,176 @@
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+ code[class*="language-"],
+ pre[class*="language-"] {
+	 color: #ABB2BF;
+	 background: none;
+	 font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	 text-align: left;
+	 white-space: pre;
+	 word-spacing: normal;
+	 word-break: normal;
+	 word-wrap: normal;
+	 line-height: 1.5;
+	 -moz-tab-size: 4;
+	 -o-tab-size: 4;
+	 tab-size: 4;
+	 -webkit-hyphens: none;
+	 -moz-hyphens: none;
+	 -ms-hyphens: none;
+	 hyphens: none;
+ }
+ 
+ pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+ code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	 text-shadow: none;
+	 background: #383e49;
+ }
+ 
+ pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+ code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	 text-shadow: none;
+	 background: #9aa2b1;
+ }
+ 
+ @media print {
+	 code[class*="language-"],
+	 pre[class*="language-"] {
+		 text-shadow: none;
+	 }
+ }
+ /* Code blocks */
+ pre[class*="language-"] {
+	 padding: 1em;
+	 margin: .5em 0;
+	 overflow: auto;
+ }
+ 
+ :not(pre) > code[class*="language-"],
+ pre[class*="language-"] {
+	 background: #282c34;
+ }
+ 
+ /* Inline code */
+ :not(pre) > code[class*="language-"] {
+	 padding: .1em;
+	 border-radius: .3em;
+	 white-space: normal;
+ }
+ 
+ .token.comment,
+ .token.prolog,
+ .token.doctype,
+ .token.cdata {
+	 color: #5C6370;
+ }
+ 
+ .token.punctuation {
+	 color: #abb2bf;
+ }
+ 
+ .token.selector,
+ .token.tag {
+	 color: #e06c75;
+ }
+ 
+ .token.property,
+ .token.boolean,
+ .token.number,
+ .token.constant,
+ .token.symbol,
+ .token.attr-name,
+ .token.deleted {
+	 color: #d19a66;
+ }
+ 
+ .token.string,
+ .token.char,
+ .token.attr-value,
+ .token.builtin,
+ .token.inserted {
+	 color: #98c379;
+ }
+ 
+ .token.operator,
+ .token.entity,
+ .token.url,
+ .language-css .token.string,
+ .style .token.string {
+	 color: #56b6c2;
+ }
+ 
+ .token.atrule,
+ .token.keyword {
+	 color: rgb(198, 120, 221);
+ }
+ 
+ .token.function {
+	 color: #61afef;
+ }
+ 
+ .token.regex {
+	color: rgb(86, 182, 194);
+ }
+
+ .token.important,
+ .token.variable {
+	 color: rgb(224, 108, 117);
+ }
+ 
+ .token.important,
+ .token.bold {
+	 font-weight: bold;
+ }
+ 
+ .token.italic {
+	 font-style: italic;
+ }
+ 
+ .token.entity {
+	 cursor: help;
+ }
+ 
+ pre.line-numbers {
+	 position: relative;
+	 padding-left: 3.8em;
+	 counter-reset: linenumber;
+ }
+ 
+ pre.line-numbers > code {
+	 position: relative;
+ }
+ 
+ .line-numbers .line-numbers-rows {
+	 position: absolute;
+	 pointer-events: none;
+	 top: 0;
+	 font-size: 100%;
+	 left: -3.8em;
+	 width: 3em; /* works for line-numbers below 1000 lines */
+	 letter-spacing: -1px;
+	 border-right: 0;
+ 
+	 -webkit-user-select: none;
+	 -moz-user-select: none;
+	 -ms-user-select: none;
+	 user-select: none;
+ 
+ }
+ 
+ .line-numbers-rows > span {
+	 pointer-events: none;
+	 display: block;
+	 counter-increment: linenumber;
+ }
+ 
+ .line-numbers-rows > span:before {
+	 content: counter(linenumber);
+	 color: #5C6370;
+	 display: block;
+	 padding-right: 0.8em;
+	 text-align: right;
+ }
+ 

--- a/website/src/styles/index.scss
+++ b/website/src/styles/index.scss
@@ -1,5 +1,6 @@
 @import "_variables";
 @import "_mixins";
+@import "_prism";
 @import "_grid";
 @import "_global";
 @import "_header";

--- a/website/static/js/index.js
+++ b/website/static/js/index.js
@@ -183,3 +183,10 @@ elements.overlay.addEventListener("touchstart", mobileToggleEvent, false);
 window.addEventListener('scroll', handleScroll, false);
 
 elements.colorSchemeSwitch.addEventListener('click', modeSwitch, false);
+
+const homepageExample = document.querySelector(".homepage-example");
+if (homepageExample !== undefined) {
+  homepageExample.addEventListener("click", () => {
+    homepageExample.classList.remove("collapsed");
+  });
+}


### PR DESCRIPTION
This PR replaces the homepage screenshot with a clickable interactive and selectable console output of running `rome check` in a sample app.

To do this I added/fixed the following:

 - `--console-format html` CLI flag that instead of ANSI prints HTML
 - `--console-columns 200` CLI flag to explicitly set the terminal width
 - `--console-redirect-error` CLI flag that will redirect all `process.stderr` to `process.stdout`
 - Better syntax highlighting. There is now a token markup tag with a `type` field that matches prismjs classes.
 - Improved ANSI syntax highlighting. We are limited by the amount of base colors that are offered. Instead I added the ability in a Rome's user config (currently undocumented) to specify a VSCode file path. We then load it up and use the color mappings. By default we use [OneDarkPro](https://marketplace.visualstudio.com/items?itemName=zhuangtongfa.Material-theme).
 - Fixed some weird line wrapping bug where a trailing word wouldn't output a space.
 - Switched monospace font on website to Fira Code
 - Switched PrismJS theme to OneDarkPro