### PR TITLE
[Website] Make IDs unique

### DIFF
--- a/website/src/_includes/layouts/base.njk
+++ b/website/src/_includes/layouts/base.njk
@@ -71,8 +71,8 @@
           </ul>
         </nav>
 
-        <nav aria-labelledby="site-navigation" class="menu">
-          <h2 id="site-navigation">Components</h2>
+        <nav aria-labelledby="site-navigation-components" class="menu">
+          <h2 id="site-navigation-components">Components</h2>
           <ul>
             <li>
               <a href="{{ '/docs/lint' | url }}">Linting</a>
@@ -80,8 +80,8 @@
           </ul>
         </nav>
 
-        <nav aria-labelledby="site-navigation" class="menu">
-          <h2 id="site-navigation">Documentation</h2>
+        <nav aria-labelledby="site-navigation-documentation" class="menu">
+          <h2 id="site-navigation-documentation">Documentation</h2>
           <ul>
             <li>
               <a href="{{ '/docs/getting-started' | url }}">Getting Started</a>


### PR DESCRIPTION
The navigation bar has repeated ids called `site-navigation`. This causes issue to assistive technologies. 

This PR makes them unique