### PR TITLE
"Getting Started" -> "Get Started" on the homepage

### DIFF
--- a/website/src/index.md
+++ b/website/src/index.md
@@ -37,7 +37,7 @@ Rome aims to have the following responsibilities:
 
 <ul class="home-actions">
 	<li>
-		<a class="getting-started" href="/docs/getting-started">Getting Started</a>
+		<a class="getting-started" href="/docs/getting-started">Get Started</a>
 	</li>
 </ul>
 


### PR DESCRIPTION
On the homepage "Getting Started" is a call to action so "Get Started" reads better.