### PR TITLE
JavaScript Toolchain -> Frontend Toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
   <img alt="Rome, logo of an ancient Greek spartan helmet" src="https://github.com/romejs/rome/raw/main/assets/PNG/logo_transparent.png" width="700">
 </p>
 
-**Rome** is an experimental JavaScript toolchain. It includes a compiler, linter, formatter, bundler, testing framework and more. It aims to be a comprehensive tool for anything related to the processing of JavaScript source code.
+**Rome** is a linter, compiler, bundler, and more for JavaScript, HTML, and CSS. It unifies functionality that have previously been completely separate tools. We have support for JavaScript flavors such as TypeScript and JSX.
 
-**Rome** is not a collection of existing tools. All components are custom and use no third-party dependencies.
+[Babel](https://babeljs.io/), [Webpack](https://webpack.js.org/), [Jest](https://jestjs.io/), [ESLint](https://eslint.org/), and other frontend tooling have a significant overlap in responsibilities and implementation. There is value in these being a single tool.
 
-**Rome** is experimental and in active development. It's open for contributors and those interested in experimental tools. **It is not ready for production usage. The only way to use it is to build from source.**
+Building upon a shared base allows us to provide a cohesive experience for processing code, displaying errors, parallelizing work, caching, and configuration.
 
-**Rome** aims to be a replacement for many existing JavaScript tools. We will, however, offer integrations for components in other tools. For example, using the Rome compiler as a plugin for another bundler.
+**Rome** has strong conventions and we aim to have minimal configuration. By using Rome you accept the conventions we have set. Read more about our philosophy [here](/contributing/philosophy).
+
+**Rome** is maintained by a [team of contributors](/contributing/team). **Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
 
 **Rome** is [MIT licensed](LICENSE), and the project managed under the [Contributor Covenant Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## History
-
-**Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
 
 **Rome** gets its name from proverbs such as "All Roads Lead to Rome", "Rome wasn't built in a day" and "When in Rome, do as the Romans do". This refers to the expansive scope and the desire for conformity across the project. It started as a joke at the office.
 

--- a/website/src/_includes/layouts/base.njk
+++ b/website/src/_includes/layouts/base.njk
@@ -90,13 +90,13 @@
               <a href="{{ '/docs/cli' | url }}">CLI</a>
             </li>
             <li>
-              <a href="{{ '/docs/project-config' | url }}">Project Config</a>
-            </li>
-            <li>
               <a href="{{ '/docs/diagnostics' | url }}">Diagnostics</a>
             </li>
             <li>
               <a href="{{ '/docs/editor-integration' | url }}">Editor Integration</a>
+            </li>
+            <li>
+              <a href="{{ '/docs/project-config' | url }}">Project Config</a>
             </li>
           </ul>
         </nav>

--- a/website/src/_includes/layouts/sections/head.njk
+++ b/website/src/_includes/layouts/sections/head.njk
@@ -1,5 +1,5 @@
 <head>
-	<title>{{ title }}{{ " — " if title }}Rome JavaScript toolchain</title>
+	<title>{{ title }}{{ " — " if title }}Rome Frontend Toolchain</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <link rel="mask-icon" href="{{ '/static/img/pinned-rome-logo.svg' | url }}" color="#000000">

--- a/website/src/_includes/layouts/sections/hero.njk
+++ b/website/src/_includes/layouts/sections/hero.njk
@@ -1,4 +1,4 @@
 <div class="hero">
-	<h1>The Rome JavaScript toolchain</h1>
-	<h2>Standardizing the JavaScript developer experience</h2>
+	<h1>The Rome Frontend Toolchain</h1>
+	<h2>Standardizing the web development experience</h2>
 </div>

--- a/website/src/contributing/governance.md
+++ b/website/src/contributing/governance.md
@@ -1,5 +1,5 @@
 ---
-title: Governance - Rome JavaScript toolchain
+title: Governance
 layout: layouts/base.njk
 showHero: false
 ---

--- a/website/src/contributing/index.md
+++ b/website/src/contributing/index.md
@@ -1,5 +1,5 @@
 ---
-title: Contributing - Rome JavaScript toolchain
+title: Contributing
 layout: layouts/base.njk
 showHero: false
 ---

--- a/website/src/contributing/team.md
+++ b/website/src/contributing/team.md
@@ -1,5 +1,5 @@
 ---
-title: Team - Rome JavaScript toolchain
+title: Team
 layout: layouts/base.njk
 showHero: false
 ---

--- a/website/src/docs/check/rules/camel-case.md
+++ b/website/src/docs/check/rules/camel-case.md
@@ -1,5 +1,5 @@
 ---
-title: Rome - A JavaScript toolchain
+title: Rome
 layout: layouts/base.njk
 showHero: false
 description: This rule enforce the use of camelCase

--- a/website/src/docs/check/rules/index.md
+++ b/website/src/docs/check/rules/index.md
@@ -1,5 +1,5 @@
 ---
-title: Rome - A JavaScript toolchain
+title: Rome
 layout: layouts/base.njk
 showHero: false
 ---

--- a/website/src/index.md
+++ b/website/src/index.md
@@ -3,15 +3,15 @@ layout: layouts/base.njk
 showHero: true
 ---
 
-**Rome** is a linter, compiler, bundler, and [more](#responsibilities). It unifies functionality that have previously been completely separate tools. We have full support for JavaScript, TypeScript and JSX syntax.
+**Rome** is a linter, compiler, bundler, and [more](#responsibilities) for JavaScript, HTML, and CSS. It unifies functionality that have previously been completely separate tools. We have support for JavaScript flavors such as TypeScript and JSX.
 
-[Babel](https://babeljs.io/), [Webpack](https://webpack.js.org/), [Jest](https://jestjs.io/), [ESLint](https://eslint.org/), and other JavaScript language tooling have a significant overlap in responsibilities and implementation.
+[Babel](https://babeljs.io/), [Webpack](https://webpack.js.org/), [Jest](https://jestjs.io/), [ESLint](https://eslint.org/), and other frontend tooling have a significant overlap in responsibilities and implementation. There is value in these being a single tool.
 
-There is value in these being a single tool. Building upon a shared base allows us to provide a cohesive experience for processing JavaScript, displaying errors, parallelizing work, caching, and configuration.
+Building upon a shared base allows us to provide a cohesive experience for processing code, displaying errors, parallelizing work, caching, and configuration.
 
-**Rome** has strong conventions and we aim to have minimal configuration. By using Rome you accept the conventions we have set. Read more about our philosophy [here](/contributing/philosophy).
+**Rome** has strong conventions and we aim to have minimal configuration. By using Rome you accept the conventions we have set. Read more about our philosophy [here](https://preview.romejs.dev/contributing/philosophy).
 
-**Rome** is maintained by a [team of contributors](/contributing/team). **Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
+**Rome** is maintained by a [team of contributors](https://preview.romejs.dev/contributing/team). **Rome** was started by [Sebastian McKenzie](https://twitter.com/sebmck), the author of [Babel](https://babeljs.io) and [Yarn](https://yarnpkg.com).
 
 ## Preview
 
@@ -20,6 +20,8 @@ There is value in these being a single tool. Building upon a shared base allows 
 ## Development status
 
 **Rome is currently only supported as a [linter](/docs/lint).** As Rome's use as a linter stabilizes we will begin polishing the other components for release and usage.
+
+**Rome currently only supports JavaScript.** We have future plans to support HTML and CSS.
 
 Rome aims to have the following responsibilities:
 


### PR DESCRIPTION
This updates the website and README to move from the term "JavaScript Toolchain" to "Frontend Toolchain". We have long term plans to support HTML and CSS. We should set appropriate expectations at launch.

I was considering "Web Toolchain" but it may carry a web server/backend connotation.

We may be ostracizing backend Node.js engineers until we have established ourselves more, but I don't think there's an appropriate term that covers everything.

"Frontend" is still regularly used to JavaScript related software engineering, including React Native and other alternate web stacks.