### PR TITLE
Add preferInterfaces lint rule*

### DIFF
--- a/packages/@romejs/ast/index.ts
+++ b/packages/@romejs/ast/index.ts
@@ -189,6 +189,7 @@ export * from "./js/typescript/TSNullKeywordTypeAnnotation";
 export * from "./js/typescript/TSNumberKeywordTypeAnnotation";
 export * from "./js/typescript/TSNumericLiteralTypeAnnotation";
 export * from "./js/typescript/TSObjectKeywordTypeAnnotation";
+export * from "./js/typescript/TSObjectTypeAnnotation";
 export * from "./js/typescript/TSParenthesizedType";
 export * from "./js/typescript/TSPropertySignature";
 export * from "./js/typescript/TSQualifiedName";
@@ -202,7 +203,6 @@ export * from "./js/typescript/TSTupleElement";
 export * from "./js/typescript/TSTupleType";
 export * from "./js/typescript/TSTypeAlias";
 export * from "./js/typescript/TSTypeAssertion";
-export * from "./js/typescript/TSObjectTypeAnnotation";
 export * from "./js/typescript/TSTypeOperator";
 export * from "./js/typescript/TSTypeParameter";
 export * from "./js/typescript/TSTypeParameterDeclaration";
@@ -398,6 +398,7 @@ export type AnyNode =
 	| n.TSNumberKeywordTypeAnnotation
 	| n.TSNumericLiteralTypeAnnotation
 	| n.TSObjectKeywordTypeAnnotation
+	| n.TSObjectTypeAnnotation
 	| n.TSParenthesizedType
 	| n.TSPropertySignature
 	| n.TSQualifiedName
@@ -411,7 +412,6 @@ export type AnyNode =
 	| n.TSTupleType
 	| n.TSTypeAlias
 	| n.TSTypeAssertion
-	| n.TSObjectTypeAnnotation
 	| n.TSTypeOperator
 	| n.TSTypeParameter
 	| n.TSTypeParameterDeclaration

--- a/packages/@romejs/ast/index.ts
+++ b/packages/@romejs/ast/index.ts
@@ -200,9 +200,9 @@ export * from "./js/typescript/TSTemplateLiteralTypeAnnotation";
 export * from "./js/typescript/TSThisType";
 export * from "./js/typescript/TSTupleElement";
 export * from "./js/typescript/TSTupleType";
-export * from "./js/typescript/TSTypeAliasTypeAnnotation";
+export * from "./js/typescript/TSTypeAlias";
 export * from "./js/typescript/TSTypeAssertion";
-export * from "./js/typescript/TSTypeLiteral";
+export * from "./js/typescript/TSObjectTypeAnnotation";
 export * from "./js/typescript/TSTypeOperator";
 export * from "./js/typescript/TSTypeParameter";
 export * from "./js/typescript/TSTypeParameterDeclaration";
@@ -409,9 +409,9 @@ export type AnyNode =
 	| n.TSThisType
 	| n.TSTupleElement
 	| n.TSTupleType
-	| n.TSTypeAliasTypeAnnotation
+	| n.TSTypeAlias
 	| n.TSTypeAssertion
-	| n.TSTypeLiteral
+	| n.TSObjectTypeAnnotation
 	| n.TSTypeOperator
 	| n.TSTypeParameter
 	| n.TSTypeParameterDeclaration

--- a/packages/@romejs/ast/js/modules/JSExportLocalDeclaration.ts
+++ b/packages/@romejs/ast/js/modules/JSExportLocalDeclaration.ts
@@ -16,7 +16,7 @@ import {
 	TSEnumDeclaration,
 	TSInterfaceDeclaration,
 	TSModuleDeclaration,
-	TSTypeAliasTypeAnnotation,
+	TSTypeAlias,
 } from "@romejs/ast";
 import {createBuilder} from "../../utils";
 
@@ -29,7 +29,7 @@ export type JSExportLocalDeclaration = JSNodeBase & {
 		| JSClassDeclaration
 		| TSModuleDeclaration
 		| TSEnumDeclaration
-		| TSTypeAliasTypeAnnotation
+		| TSTypeAlias
 		| TSInterfaceDeclaration
 		| TSDeclareFunction;
 	specifiers?: Array<JSExportLocalSpecifier>;

--- a/packages/@romejs/ast/js/typescript/TSObjectTypeAnnotation.ts
+++ b/packages/@romejs/ast/js/typescript/TSObjectTypeAnnotation.ts
@@ -8,13 +8,13 @@
 import {AnyTSTypeElement, JSNodeBase} from "@romejs/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeLiteral = JSNodeBase & {
-	type: "TSTypeLiteral";
+export type TSObjectTypeAnnotation = JSNodeBase & {
+	type: "TSObjectTypeAnnotation";
 	members: Array<AnyTSTypeElement>;
 };
 
-export const tsTypeLiteral = createBuilder<TSTypeLiteral>(
-	"TSTypeLiteral",
+export const tsObjectTypeAnnotation = createBuilder<TSObjectTypeAnnotation>(
+	"TSObjectTypeAnnotation",
 	{
 		bindingKeys: {},
 		visitorKeys: {

--- a/packages/@romejs/ast/js/typescript/TSTypeAlias.ts
+++ b/packages/@romejs/ast/js/typescript/TSTypeAlias.ts
@@ -13,16 +13,16 @@ import {
 } from "@romejs/ast";
 import {createBuilder} from "../../utils";
 
-export type TSTypeAliasTypeAnnotation = JSNodeBase & {
-	type: "TSTypeAliasTypeAnnotation";
+export type TSTypeAlias = JSNodeBase & {
+	type: "TSTypeAlias";
 	id: JSBindingIdentifier;
 	typeParameters?: TSTypeParameterDeclaration;
 	right: AnyTSPrimary;
 	declare?: boolean | undefined;
 };
 
-export const tsTypeAliasTypeAnnotation = createBuilder<TSTypeAliasTypeAnnotation>(
-	"TSTypeAliasTypeAnnotation",
+export const tsTypeAlias = createBuilder<TSTypeAlias>(
+	"TSTypeAlias",
 	{
 		bindingKeys: {
 			id: true,

--- a/packages/@romejs/ast/js/unions.ts
+++ b/packages/@romejs/ast/js/unions.ts
@@ -239,7 +239,7 @@ export type AnyJSDeclaration =
 	| n.JSExportDefaultDeclaration
 	| n.JSExportExternalDeclaration
 	| n.JSExportAllDeclaration
-	| n.TSTypeAliasTypeAnnotation
+	| n.TSTypeAlias
 	| n.TSEnumDeclaration
 	| n.TSInterfaceDeclaration
 	| n.TSNamespaceExportDeclaration
@@ -267,7 +267,7 @@ export type AnyTSKeywordTypeAnnotation =
 	| n.TSUnknownKeywordTypeAnnotation;
 
 export type AnyTSPrimary =
-	| n.TSTypeLiteral
+	| n.TSObjectTypeAnnotation
 	| n.TSTypeReference
 	| n.TSThisType
 	| n.TSParenthesizedType

--- a/packages/@romejs/ast/utils.ts
+++ b/packages/@romejs/ast/utils.ts
@@ -28,8 +28,10 @@ type JustNodeKeys<T> = ExcludeCoreNodeKeys<
 
 type ExcludeCoreNodeKeys<T> = Exclude<T, keyof JSNodeBase>;
 
+// rome-ignore lint/js/noUnusedVariables
 type VisitorKeys<T> = {[K in JustNodeKeys<T>]: true};
 
+// rome-ignore lint/js/noUnusedVariables
 type BindingKeys<T> = {[K in JustNodeKeys<T>]?: true};
 
 type CreateBuilderOptions<Node> = {

--- a/packages/@romejs/compiler/lint/index.ts
+++ b/packages/@romejs/compiler/lint/index.ts
@@ -30,20 +30,20 @@ export default async function lint(req: LintRequest): Promise<LintResult> {
 	}
 
 	// Perform autofixes
-	const formatContext = new CompilerContext({
-		ref: req.ref,
-		sourceText: req.sourceText,
-		options,
-		ast,
-		project,
-		frozen: false,
-		origin: {
-			category: "check",
-		},
-	});
-
 	let formatAst = ast;
 	if (applyRecommendedFixes) {
+		const formatContext = new CompilerContext({
+			ref: req.ref,
+			sourceText: req.sourceText,
+			options,
+			ast,
+			project,
+			frozen: false,
+			origin: {
+				category: "check",
+			},
+		});
+
 		formatAst = formatContext.reduceRoot(ast, lintTransforms);
 		formatAst = addSuppressions(formatContext, formatAst);
 	}
@@ -69,7 +69,10 @@ export default async function lint(req: LintRequest): Promise<LintResult> {
 		},
 		frozen: true,
 	});
-	context.reduceRoot(ast, lintTransforms);
+	const newAst = context.reduceRoot(ast, lintTransforms);
+	if (ast !== newAst) {
+		throw new Error("Expected the same ast. `frozen: true` is broken");
+	}
 
 	const diagnostics = context.diagnostics.getDiagnostics();
 	const result: LintResult = {

--- a/packages/@romejs/compiler/lint/rules/index.ts
+++ b/packages/@romejs/compiler/lint/rules/index.ts
@@ -108,6 +108,7 @@ import sortComp from "./react/sortComp";
 import stylePropObject from "./react/stylePropObject";
 import voidDomElementsNoChildren from "./react/voidDomElementsNoChildren";
 import noExplicitAny from "./ts/noExplicitAny";
+import preferInterfaces from "./ts/preferInterfaces";
 
 export const lintTransforms = [
 	camelCase,
@@ -212,4 +213,5 @@ export const lintTransforms = [
 	stylePropObject,
 	voidDomElementsNoChildren,
 	noExplicitAny,
+	preferInterfaces,
 ];

--- a/packages/@romejs/compiler/lint/rules/js/undeclaredVariables.ts
+++ b/packages/@romejs/compiler/lint/rules/js/undeclaredVariables.ts
@@ -6,7 +6,6 @@
  */
 
 import {Path} from "@romejs/compiler";
-import {isInTypeAnnotation} from "@romejs/js-ast-utils";
 import {AnyNode} from "@romejs/ast";
 import {descriptions} from "@romejs/diagnostics";
 
@@ -35,15 +34,45 @@ const BROWSER_VARIABLES = [
 	"performance",
 ];
 
+// This is gross...
+const TS_VARIABLES = [
+	"MethodDecorator",
+	"ParameterDecorator",
+	"PromiseConstructorLike",
+	"PromiseLike",
+	"Promise",
+	"ArrayLike",
+	"Partial",
+	"Required",
+	"Readonly",
+	"Pick",
+	"Record",
+	"Exclude",
+	"Extract",
+	"Omit",
+	"NonNullable",
+	"Parameters",
+	"ConstructorParameters",
+	"ReturnType",
+	"InstanceType",
+	"ThisType",
+	"NodeJS",
+	"Iterable",
+	"Iterator",
+	"TemplateStringsArray",
+	"BufferEncoding",
+	"Console",
+	"Thenable",
+];
+
 export default {
 	name: "undeclaredVariables",
 	enter(path: Path): AnyNode {
 		const {node, scope} = path;
 
 		if (
-			(node.type === "JSReferenceIdentifier" ||
-			node.type === "JSXReferenceIdentifier") &&
-			!isInTypeAnnotation(path)
+			node.type === "JSReferenceIdentifier" ||
+			node.type === "JSXReferenceIdentifier"
 		) {
 			const {name} = node;
 			const binding = scope.getBinding(name);
@@ -52,7 +81,8 @@ export default {
 				binding !== undefined ||
 				scope.isGlobal(name) ||
 				BROWSER_VARIABLES.includes(name) ||
-				NODE_VARIABLES.includes(name);
+				NODE_VARIABLES.includes(name) ||
+				TS_VARIABLES.includes(name);
 
 			if (!isDefined) {
 				path.context.addNodeDiagnostic(

--- a/packages/@romejs/compiler/lint/rules/react/noUselessFragment.test.md
+++ b/packages/@romejs/compiler/lint/rules/react/noUselessFragment.test.md
@@ -101,18 +101,19 @@
 
 ```
 
- unknown lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
+
+    <React.Fragment>foo</React.Fragment>
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   ℹ A Fragment is redundant if it contains only one child, or if it is the child of a html element,
     and is not a keyed fragment.
 
   ℹ Recommended fix
 
-  + foo
-
-  ✖ Unable to find target location
+  - <React.Fragment>foo</React.Fragment>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -131,18 +132,19 @@ foo;
 
 ```
 
- unknown lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ unknown:1 lint/react/noUselessFragment  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   ✖ Avoid using unnecessary Fragment.
+
+    <Fragment>foo</Fragment>
+    ^^^^^^^^^^^^^^^^^^^^^^^^
 
   ℹ A Fragment is redundant if it contains only one child, or if it is the child of a html element,
     and is not a keyed fragment.
 
   ℹ Recommended fix
 
-  + foo
-
-  ✖ Unable to find target location
+  - <Fragment>foo</Fragment>
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 

--- a/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.test.ts
+++ b/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.test.ts
@@ -7,8 +7,7 @@ test(
 		await testLint(
 			t,
 			{
-				invalid: [""],
-				valid: [""],
+				// TODO
 			},
 			{category: "lint/ts/preferInterfaces"},
 		);

--- a/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.test.ts
+++ b/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.test.ts
@@ -1,0 +1,16 @@
+import {test} from "rome";
+import {testLint} from "../../utils/testing";
+
+test(
+	"ts prefer interfaces",
+	async (t) => {
+		await testLint(
+			t,
+			{
+				invalid: [""],
+				valid: [""],
+			},
+			{category: "lint/ts/preferInterfaces"},
+		);
+	},
+);

--- a/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.ts
+++ b/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.ts
@@ -1,12 +1,11 @@
 import {Path, Scope, TransformExitResult} from "@romejs/compiler";
-import {descriptions} from "@romejs/diagnostics";
 import {
 	AnyTSTypeElement,
 	TSExpressionWithTypeArguments,
 	TSTypeAlias,
 } from "@romejs/ast";
-import { getTSQualifiedBaseFromEntityName } from "@romejs/js-ast-utils";
-import { TypeBinding } from "@romejs/compiler/scope/bindings";
+import {getTSQualifiedBaseFromEntityName} from "@romejs/js-ast-utils";
+import {TypeBinding} from "@romejs/compiler/scope/bindings";
 
 function extractObjects(
 	typeAlias: TSTypeAlias,
@@ -38,7 +37,10 @@ function extractObjects(
 			const base = getTSQualifiedBaseFromEntityName(node.typeName);
 			const binding = scope.getBinding(base.name);
 
-			if (binding === undefined || (binding instanceof TypeBinding && binding.typeKind === "parameter")) {
+			if (
+				binding === undefined ||
+				(binding instanceof TypeBinding && binding.typeKind === "parameter")
+			) {
 				// `extends` can only access a static type
 				return undefined;
 			}
@@ -65,25 +67,27 @@ export default {
 		if (node.type === "TSTypeAlias") {
 			const extracted = extractObjects(node, path.scope);
 
-			if (extracted !== undefined && extracted.extends.length === 0) {
-				return path.context.addFixableDiagnostic(
+			if (extracted !== undefined) {
+				/*return path.context.addFixableDiagnostic(
 					{
 						old: node,
-						fixed: {
-							type: "TSInterfaceDeclaration",
-							loc: node.loc,
-							id: node.id,
-							typeParameters: node.typeParameters,
-							declare: node.declare,
-							extends: extracted.extends,
-							body: {
-								type: "TSInterfaceBody",
-								body: extracted.members,
+						suggestions: [{
+							fixed: {
+								type: "TSInterfaceDeclaration",
+								loc: node.loc,
+								id: node.id,
+								typeParameters: node.typeParameters,
+								declare: node.declare,
+								extends: extracted.extends,
+								body: {
+									type: "TSInterfaceBody",
+									body: extracted.members,
+								},
 							},
-						},
+						}]
 					},
 					descriptions.LINT.TS_PREFER_INTERFACES,
-				);
+				);*/
 			}
 		}
 

--- a/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.ts
+++ b/packages/@romejs/compiler/lint/rules/ts/preferInterfaces.ts
@@ -1,0 +1,92 @@
+import {Path, Scope, TransformExitResult} from "@romejs/compiler";
+import {descriptions} from "@romejs/diagnostics";
+import {
+	AnyTSTypeElement,
+	TSExpressionWithTypeArguments,
+	TSTypeAlias,
+} from "@romejs/ast";
+import { getTSQualifiedBaseFromEntityName } from "@romejs/js-ast-utils";
+import { TypeBinding } from "@romejs/compiler/scope/bindings";
+
+function extractObjects(
+	typeAlias: TSTypeAlias,
+	scope: Scope,
+):
+	| undefined
+	| {
+			extends: Array<TSExpressionWithTypeArguments>;
+			members: Array<AnyTSTypeElement>;
+		} {
+	const {right} = typeAlias;
+
+	let types;
+	if (right.type === "TSObjectTypeAnnotation") {
+		types = [right];
+	} else if (right.type === "TSIntersectionTypeAnnotation") {
+		types = right.types;
+	} else {
+		return undefined;
+	}
+
+	const _extends: Array<TSExpressionWithTypeArguments> = [];
+	let members: Array<AnyTSTypeElement> = [];
+
+	for (const node of types) {
+		if (node.type === "TSObjectTypeAnnotation") {
+			members = members.concat(node.members);
+		} else if (node.type === "TSTypeReference") {
+			const base = getTSQualifiedBaseFromEntityName(node.typeName);
+			const binding = scope.getBinding(base.name);
+
+			if (binding === undefined || (binding instanceof TypeBinding && binding.typeKind === "parameter")) {
+				// `extends` can only access a static type
+				return undefined;
+			}
+
+			_extends.push({
+				type: "TSExpressionWithTypeArguments",
+				expression: node.typeName,
+				typeParameters: node.typeParameters,
+			});
+		} else {
+			// No idea what this is or how to include it
+			return undefined;
+		}
+	}
+
+	return {extends: _extends, members};
+}
+
+export default {
+	name: "tsPreferInterfaces",
+	enter(path: Path): TransformExitResult {
+		const {node} = path;
+
+		if (node.type === "TSTypeAlias") {
+			const extracted = extractObjects(node, path.scope);
+
+			if (extracted !== undefined && extracted.extends.length === 0) {
+				return path.context.addFixableDiagnostic(
+					{
+						old: node,
+						fixed: {
+							type: "TSInterfaceDeclaration",
+							loc: node.loc,
+							id: node.id,
+							typeParameters: node.typeParameters,
+							declare: node.declare,
+							extends: extracted.extends,
+							body: {
+								type: "TSInterfaceBody",
+								body: extracted.members,
+							},
+						},
+					},
+					descriptions.LINT.TS_PREFER_INTERFACES,
+				);
+			}
+		}
+
+		return node;
+	},
+};

--- a/packages/@romejs/compiler/methods/reduce.ts
+++ b/packages/@romejs/compiler/methods/reduce.ts
@@ -106,6 +106,10 @@ function runExit<State>(
 	// Call transformer
 	let transformedNode = callback(path, state);
 
+	if (path.context.frozen) {
+		return [KEEP_EXIT, path];
+	}
+
 	// Validate the node
 	validateTransformReturn(name, transformedNode, path);
 
@@ -141,22 +145,24 @@ export default function reduce(
 		// Call transformer
 		let transformedNode = enter(path);
 
-		// When returning this symbol, it indicates we should skip the subtree
-		if (transformedNode === REDUCE_SKIP_SUBTREE) {
-			return origNode;
-		}
+		if (!path.context.frozen) {
+			// When returning this symbol, it indicates we should skip the subtree
+			if (transformedNode === REDUCE_SKIP_SUBTREE) {
+				return origNode;
+			}
 
-		// Validate the return value
-		validateTransformReturn(visitor.name, transformedNode, path);
+			// Validate the return value
+			validateTransformReturn(visitor.name, transformedNode, path);
 
-		// Check if we need to bail out. See the comment for shouldBailReduce on what that means
-		if (shouldBailReduce(transformedNode)) {
-			return transformedNode;
-		}
+			// Check if we need to bail out. See the comment for shouldBailReduce on what that means
+			if (shouldBailReduce(transformedNode)) {
+				return transformedNode;
+			}
 
-		// Create new path if node has been changed
-		if (transformedNode !== path.node) {
-			path = path.fork(transformedNode);
+			// Create new path if node has been changed
+			if (transformedNode !== path.node) {
+				path = path.fork(transformedNode);
+			}
 		}
 	}
 

--- a/packages/@romejs/compiler/scope/bindings.ts
+++ b/packages/@romejs/compiler/scope/bindings.ts
@@ -90,9 +90,10 @@ export type TypeBindingKind =
 	| "function"
 	| "class"
 	| "interface"
-	| "typealias"
+	| "alias"
 	| "parameter"
-	| "enum";
+	| "enum"
+	| "parameter";
 
 export class TypeBinding extends ConstBinding {
 	constructor(

--- a/packages/@romejs/compiler/scope/evaluators/TSMappedType.ts
+++ b/packages/@romejs/compiler/scope/evaluators/TSMappedType.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Scope from "../Scope";
+import {AnyNode, tsMappedType} from "@romejs/ast";
+import {createScopeEvaluator} from "./index";
+
+export default createScopeEvaluator({
+	enter(node: AnyNode, parent: AnyNode, scope: Scope) {
+		node = tsMappedType.assert(node);
+		const newScope = scope.fork("type-generic", node);
+		newScope.injectEvaluate(node.typeParameter);
+		return newScope;
+	},
+});

--- a/packages/@romejs/compiler/scope/evaluators/TSTypeAlias.ts
+++ b/packages/@romejs/compiler/scope/evaluators/TSTypeAlias.ts
@@ -6,13 +6,13 @@
  */
 
 import Scope from "../Scope";
-import {AnyNode, tsInterfaceDeclaration} from "@romejs/ast";
 import {TypeBinding} from "@romejs/compiler";
+import {AnyNode, tsTypeAlias} from "@romejs/ast";
 import {createScopeEvaluator} from "./index";
 
 export default createScopeEvaluator({
 	inject(node: AnyNode, parent: AnyNode, scope: Scope) {
-		node = tsInterfaceDeclaration.assert(node);
+		node = tsTypeAlias.assert(node);
 		scope.addBinding(
 			new TypeBinding(
 				{
@@ -21,13 +21,13 @@ export default createScopeEvaluator({
 					scope,
 				},
 				node,
-				"interface",
+				"alias",
 			),
 		);
 	},
 
 	enter(node: AnyNode, parent: AnyNode, scope: Scope) {
-		node = tsInterfaceDeclaration.assert(node);
+		node = tsTypeAlias.assert(node);
 		const newScope = scope.fork("type-generic", node);
 		newScope.injectEvaluate(node.typeParameters);
 		return newScope;

--- a/packages/@romejs/compiler/scope/evaluators/TSTypeParameter.ts
+++ b/packages/@romejs/compiler/scope/evaluators/TSTypeParameter.ts
@@ -7,29 +7,22 @@
 
 import Scope from "../Scope";
 import {TypeBinding} from "@romejs/compiler";
-import {AnyNode, tsTypeAliasTypeAnnotation} from "@romejs/ast";
+import {AnyNode, tsTypeParameter} from "@romejs/ast";
 import {createScopeEvaluator} from "./index";
 
 export default createScopeEvaluator({
 	inject(node: AnyNode, parent: AnyNode, scope: Scope) {
-		node = tsTypeAliasTypeAnnotation.assert(node);
+		node = tsTypeParameter.assert(node);
 		scope.addBinding(
 			new TypeBinding(
 				{
-					node: node.id,
-					name: node.id.name,
+					node,
+					name: node.name,
 					scope,
 				},
 				node,
-				"typealias",
+				"parameter",
 			),
 		);
-	},
-
-	enter(node: AnyNode, parent: AnyNode, scope: Scope) {
-		node = tsTypeAliasTypeAnnotation.assert(node);
-		const newScope = scope.fork("type-generic", node);
-		newScope.injectEvaluate(node.typeParameters);
-		return newScope;
 	},
 });

--- a/packages/@romejs/compiler/scope/evaluators/TSTypeParameterDeclaration.ts
+++ b/packages/@romejs/compiler/scope/evaluators/TSTypeParameterDeclaration.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Scope from "../Scope";
+import {AnyNode, tsTypeParameterDeclaration} from "@romejs/ast";
+import {createScopeEvaluator} from "./index";
+
+export default createScopeEvaluator({
+	inject(node: AnyNode, parent: AnyNode, scope: Scope) {
+		node = tsTypeParameterDeclaration.assert(node);
+		for (const param of node.params) {
+			scope.injectEvaluate(param, node);
+		}
+	},
+});

--- a/packages/@romejs/compiler/scope/evaluators/index.ts
+++ b/packages/@romejs/compiler/scope/evaluators/index.ts
@@ -6,10 +6,12 @@
  */
 
 import Scope from "../Scope";
+import TSTypeParameterDeclaration from "./TSTypeParameterDeclaration";
+import TSTypeParameter from "./TSTypeParameter";
 import JSClassDeclaration from "./JSClassDeclaration";
 import JSFunctionDeclaration from "./JSFunctionDeclaration";
 import JSVariableDeclaration from "./JSVariableDeclaration";
-import TSTypeAliasTypeAnnotation from "./TSTypeAliasTypeAnnotation";
+import TSTypeAlias from "./TSTypeAlias";
 import JSExportDefaultDeclaration from "./JSExportDefaultDeclaration";
 import JSExportLocalDeclaration from "./JSExportLocalDeclaration";
 import JSImportDeclaration from "./JSImportDeclaration";
@@ -32,6 +34,7 @@ import JSObjectMethod from "./JSObjectMethod";
 import JSClassMethod from "./JSClassMethod";
 import TSDeclareMethod from "./TSDeclareMethod";
 import JSForInStatement from "./JSForInStatement";
+import TSMappedType from "./TSMappedType";
 import {AnyNode} from "@romejs/ast";
 
 export type ScopeEvaluator = {
@@ -45,6 +48,9 @@ export function createScopeEvaluator<T extends ScopeEvaluator>(obj: T): T {
 
 const evaluators: Map<string, ScopeEvaluator> = new Map();
 
+evaluators.set("TSMappedType", TSMappedType);
+evaluators.set("TSTypeParameter", TSTypeParameter);
+evaluators.set("TSTypeParameterDeclaration", TSTypeParameterDeclaration);
 evaluators.set("TSDeclareMethod", TSDeclareMethod);
 evaluators.set("TSDeclareFunction", TSDeclareFunction);
 evaluators.set("JSClassDeclaration", JSClassDeclaration);
@@ -57,7 +63,7 @@ evaluators.set("JSFunctionExpression", JSFunctionExpression);
 evaluators.set("JSImportDeclaration", JSImportDeclaration);
 evaluators.set("JSSwitchCase", JSSwitchCase);
 evaluators.set("JSSwitchStatement", JSSwitchStatement);
-evaluators.set("TSTypeAliasTypeAnnotation", TSTypeAliasTypeAnnotation);
+evaluators.set("TSTypeAlias", TSTypeAlias);
 evaluators.set("TSImportEqualsDeclaration", TSImportEqualsDeclaration);
 evaluators.set("JSArrowFunctionExpression", JSArrowFunctionExpression);
 evaluators.set("JSBlockStatement", JSBlockStatement);

--- a/packages/@romejs/compiler/transforms/compileForBundle/legacy/esToCJSTransform.ts
+++ b/packages/@romejs/compiler/transforms/compileForBundle/legacy/esToCJSTransform.ts
@@ -119,7 +119,7 @@ export default {
 					if (
 						declaration.type === "TSModuleDeclaration" ||
 						declaration.type === "TSEnumDeclaration" ||
-						declaration.type === "TSTypeAliasTypeAnnotation" ||
+						declaration.type === "TSTypeAlias" ||
 						declaration.type === "TSInterfaceDeclaration" ||
 						declaration.type === "TSDeclareFunction"
 					) {

--- a/packages/@romejs/compiler/types.ts
+++ b/packages/@romejs/compiler/types.ts
@@ -28,6 +28,7 @@ export type TransformStageFactory = (
 	options: Object,
 ) => Transforms;
 
+// rome-ignore lint/js/noUnusedVariables
 export type TransformStageFactories = {
 	[key in TransformStageName]: TransformStageFactory
 };

--- a/packages/@romejs/consume/Consumer.ts
+++ b/packages/@romejs/consume/Consumer.ts
@@ -107,7 +107,7 @@ export default class Consumer {
 	hasHandledUnexpected: boolean;
 	forceDiagnosticTarget: undefined | ConsumeSourceLocationRequestTarget;
 
-	capture<T>(): {
+	capture(): {
 		consumer: Consumer;
 		definitions: Array<ConsumePropertyDefinition>;
 		diagnostics: Diagnostics;

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -196,4 +196,5 @@ type LintDiagnosticCategory =
 	| "lint/react/sortComp"
 	| "lint/react/stylePropObject"
 	| "lint/react/voidDomElementsNoChildren"
-	| "lint/ts/noExplicitAny";
+	| "lint/ts/noExplicitAny"
+	| "lint/ts/preferInterfaces";

--- a/packages/@romejs/diagnostics/descriptions/lint.ts
+++ b/packages/@romejs/diagnostics/descriptions/lint.ts
@@ -16,6 +16,10 @@ import {buildSuggestionAdvice} from "../helpers";
 import {createDiagnosticsCategory, orJoin} from "./index";
 
 export const lint = createDiagnosticsCategory({
+	TS_PREFER_INTERFACES: {
+		category: "lint/ts/preferInterfaces",
+		message: "Use an interface instead of an object type alias",
+	},
 	REACT_JSX_PROPS_NO_SPREADING: {
 		category: "lint/react/jsxPropsNoSpreading",
 		message: "Avoid using property spreading in JSX components.",

--- a/packages/@romejs/formatter/builders/index.ts
+++ b/packages/@romejs/formatter/builders/index.ts
@@ -605,14 +605,14 @@ builders.set("TSTupleElement", TSTupleElement);
 import TSTupleType from "./js/typescript/TSTupleType";
 builders.set("TSTupleType", TSTupleType);
 
-import TSTypeAliasTypeAnnotation from "./js/typescript/TSTypeAliasTypeAnnotation";
-builders.set("TSTypeAliasTypeAnnotation", TSTypeAliasTypeAnnotation);
+import TSTypeAlias from "./js/typescript/TSTypeAlias";
+builders.set("TSTypeAlias", TSTypeAlias);
 
 import TSTypeAssertion from "./js/typescript/TSTypeAssertion";
 builders.set("TSTypeAssertion", TSTypeAssertion);
 
-import TSTypeLiteral from "./js/typescript/TSTypeLiteral";
-builders.set("TSTypeLiteral", TSTypeLiteral);
+import TSObjectTypeAnnotation from "./js/typescript/TSObjectTypeAnnotation";
+builders.set("TSObjectTypeAnnotation", TSObjectTypeAnnotation);
 
 import TSTypeOperator from "./js/typescript/TSTypeOperator";
 builders.set("TSTypeOperator", TSTypeOperator);

--- a/packages/@romejs/formatter/builders/index.ts
+++ b/packages/@romejs/formatter/builders/index.ts
@@ -572,6 +572,9 @@ builders.set("TSNumericLiteralTypeAnnotation", TSNumericLiteralTypeAnnotation);
 import TSObjectKeywordTypeAnnotation from "./js/typescript/TSObjectKeywordTypeAnnotation";
 builders.set("TSObjectKeywordTypeAnnotation", TSObjectKeywordTypeAnnotation);
 
+import TSObjectTypeAnnotation from "./js/typescript/TSObjectTypeAnnotation";
+builders.set("TSObjectTypeAnnotation", TSObjectTypeAnnotation);
+
 import TSParenthesizedType from "./js/typescript/TSParenthesizedType";
 builders.set("TSParenthesizedType", TSParenthesizedType);
 
@@ -610,9 +613,6 @@ builders.set("TSTypeAlias", TSTypeAlias);
 
 import TSTypeAssertion from "./js/typescript/TSTypeAssertion";
 builders.set("TSTypeAssertion", TSTypeAssertion);
-
-import TSObjectTypeAnnotation from "./js/typescript/TSObjectTypeAnnotation";
-builders.set("TSObjectTypeAnnotation", TSObjectTypeAnnotation);
 
 import TSTypeOperator from "./js/typescript/TSTypeOperator";
 builders.set("TSTypeOperator", TSTypeOperator);

--- a/packages/@romejs/formatter/builders/js/typescript/TSInterfaceDeclaration.ts
+++ b/packages/@romejs/formatter/builders/js/typescript/TSInterfaceDeclaration.ts
@@ -27,7 +27,7 @@ export default function TSInterfaceDeclaration(
 		builder.tokenize(node.typeParameters, node),
 	);
 
-	if (node.extends) {
+	if (node.extends !== undefined && node.extends.length > 0) {
 		tokens.push(
 			space,
 			"extends",

--- a/packages/@romejs/formatter/builders/js/typescript/TSIntersectionTypeAnnotation.ts
+++ b/packages/@romejs/formatter/builders/js/typescript/TSIntersectionTypeAnnotation.ts
@@ -67,5 +67,5 @@ export default function TSIntersectionTypeAnnotation(
 }
 
 function isObjectType(node: AnyNode): boolean {
-	return node.type === "TSMappedType" || node.type === "TSTypeLiteral";
+	return node.type === "TSMappedType" || node.type === "TSObjectTypeAnnotation";
 }

--- a/packages/@romejs/formatter/builders/js/typescript/TSObjectTypeAnnotation.ts
+++ b/packages/@romejs/formatter/builders/js/typescript/TSObjectTypeAnnotation.ts
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {TSTypeLiteral} from "@romejs/ast";
+import {TSObjectTypeAnnotation} from "@romejs/ast";
 import {Builder, Token} from "@romejs/formatter";
 
 import {printTSBraced} from "../utils";
 
-export default function TSTypeLiteral(
+export default function TSObjectTypeAnnotation(
 	builder: Builder,
-	node: TSTypeLiteral,
+	node: TSObjectTypeAnnotation,
 ): Token {
 	return printTSBraced(builder, node, node.members);
 }

--- a/packages/@romejs/formatter/builders/js/typescript/TSTypeAlias.ts
+++ b/packages/@romejs/formatter/builders/js/typescript/TSTypeAlias.ts
@@ -6,12 +6,9 @@
  */
 
 import {Builder, Token, concat, group, space} from "@romejs/formatter";
-import {TSTypeAliasTypeAnnotation} from "@romejs/ast";
+import {TSTypeAlias} from "@romejs/ast";
 
-export default function TSTypeAliasTypeAnnotation(
-	builder: Builder,
-	node: TSTypeAliasTypeAnnotation,
-): Token {
+export default function TSTypeAlias(builder: Builder, node: TSTypeAlias): Token {
 	return group(
 		concat([
 			"type",

--- a/packages/@romejs/js-analysis/evaluators/index.ts
+++ b/packages/@romejs/js-analysis/evaluators/index.ts
@@ -579,6 +579,9 @@ evaluators.set("TSNumericLiteralTypeAnnotation", TSNumericLiteralTypeAnnotation)
 import TSObjectKeywordTypeAnnotation from "./typescript/TSObjectKeywordTypeAnnotation";
 evaluators.set("TSObjectKeywordTypeAnnotation", TSObjectKeywordTypeAnnotation);
 
+import TSObjectTypeAnnotation from "./typescript/TSObjectTypeAnnotation";
+evaluators.set("TSObjectTypeAnnotation", TSObjectTypeAnnotation);
+
 import TSParenthesizedType from "./typescript/TSParenthesizedType";
 evaluators.set("TSParenthesizedType", TSParenthesizedType);
 
@@ -620,9 +623,6 @@ evaluators.set("TSTypeAlias", TSTypeAlias);
 
 import TSTypeAssertion from "./typescript/TSTypeAssertion";
 evaluators.set("TSTypeAssertion", TSTypeAssertion);
-
-import TSObjectTypeAnnotation from "./typescript/TSObjectTypeAnnotation";
-evaluators.set("TSObjectTypeAnnotation", TSObjectTypeAnnotation);
 
 import TSTypeOperator from "./typescript/TSTypeOperator";
 evaluators.set("TSTypeOperator", TSTypeOperator);

--- a/packages/@romejs/js-analysis/evaluators/index.ts
+++ b/packages/@romejs/js-analysis/evaluators/index.ts
@@ -615,14 +615,14 @@ evaluators.set("TSTupleElement", TSTupleElement);
 import TSTupleType from "./typescript/TSTupleType";
 evaluators.set("TSTupleType", TSTupleType);
 
-import TSTypeAliasTypeAnnotation from "./typescript/TSTypeAliasTypeAnnotation";
-evaluators.set("TSTypeAliasTypeAnnotation", TSTypeAliasTypeAnnotation);
+import TSTypeAlias from "./typescript/TSTypeAlias";
+evaluators.set("TSTypeAlias", TSTypeAlias);
 
 import TSTypeAssertion from "./typescript/TSTypeAssertion";
 evaluators.set("TSTypeAssertion", TSTypeAssertion);
 
-import TSTypeLiteral from "./typescript/TSTypeLiteral";
-evaluators.set("TSTypeLiteral", TSTypeLiteral);
+import TSObjectTypeAnnotation from "./typescript/TSObjectTypeAnnotation";
+evaluators.set("TSObjectTypeAnnotation", TSObjectTypeAnnotation);
 
 import TSTypeOperator from "./typescript/TSTypeOperator";
 evaluators.set("TSTypeOperator", TSTypeOperator);

--- a/packages/@romejs/js-analysis/evaluators/modules/JSExportLocalDeclaration.ts
+++ b/packages/@romejs/js-analysis/evaluators/modules/JSExportLocalDeclaration.ts
@@ -47,7 +47,7 @@ export default function JSExportLocalDeclaration(
 				break;
 			}
 
-			case "TSTypeAliasTypeAnnotation": {
+			case "TSTypeAlias": {
 				const type = scope.getBinding(decl.id.name);
 				if (type === undefined) {
 					throw new Error(`Couldn't find binding type for ${decl.id.name}`);

--- a/packages/@romejs/js-analysis/evaluators/typescript/TSObjectTypeAnnotation.ts
+++ b/packages/@romejs/js-analysis/evaluators/typescript/TSObjectTypeAnnotation.ts
@@ -6,10 +6,14 @@
  */
 
 import {Scope} from "../../scopes";
-import {AnyNode, TSTypeLiteral, tsTypeLiteral} from "@romejs/ast";
+import {
+	AnyNode,
+	TSObjectTypeAnnotation,
+	tsObjectTypeAnnotation,
+} from "@romejs/ast";
 
-export default function TSTypeLiteral(node: AnyNode, scope: Scope) {
-	node = tsTypeLiteral.assert(node);
+export default function TSObjectTypeAnnotation(node: AnyNode, scope: Scope) {
+	node = tsObjectTypeAnnotation.assert(node);
 	scope;
 	throw new Error("unimplemented");
 }

--- a/packages/@romejs/js-analysis/evaluators/typescript/TSTypeAlias.ts
+++ b/packages/@romejs/js-analysis/evaluators/typescript/TSTypeAlias.ts
@@ -6,14 +6,10 @@
  */
 
 import {Scope} from "../../scopes";
-import {
-	AnyNode,
-	TSTypeAliasTypeAnnotation,
-	tsTypeAliasTypeAnnotation,
-} from "@romejs/ast";
+import {AnyNode, TSTypeAlias, tsTypeAlias} from "@romejs/ast";
 
-export default function TSTypeAliasTypeAnnotation(node: AnyNode, scope: Scope) {
-	node = tsTypeAliasTypeAnnotation.assert(node);
+export default function TSTypeAlias(node: AnyNode, scope: Scope) {
+	node = tsTypeAlias.assert(node);
 
 	const typeScope = scope.fork();
 	if (node.typeParameters) {

--- a/packages/@romejs/js-ast-utils/getNodeReferenceParts.ts
+++ b/packages/@romejs/js-ast-utils/getNodeReferenceParts.ts
@@ -56,7 +56,7 @@ export default function getNodeReferenceParts(node: undefined | AnyNode): Result
 					return true;
 				}
 			}
-			
+
 			case "TSStringLiteralTypeAnnotation":
 			case "JSStringLiteral": {
 				parts.push({node, value: node.value});

--- a/packages/@romejs/js-ast-utils/getTSQualifiedBaseFromEntityName.ts
+++ b/packages/@romejs/js-ast-utils/getTSQualifiedBaseFromEntityName.ts
@@ -1,0 +1,11 @@
+import { AnyTSEntityName, JSReferenceIdentifier} from "@romejs/ast";
+
+export default function getTSQualifiedBaseFromEntityName(entity: AnyTSEntityName): JSReferenceIdentifier {
+	switch (entity.type) {
+		case "TSQualifiedName":
+			return getTSQualifiedBaseFromEntityName(entity.left);
+
+		case "JSReferenceIdentifier":
+			return entity;
+	}
+}

--- a/packages/@romejs/js-ast-utils/getTSQualifiedBaseFromEntityName.ts
+++ b/packages/@romejs/js-ast-utils/getTSQualifiedBaseFromEntityName.ts
@@ -1,6 +1,8 @@
-import { AnyTSEntityName, JSReferenceIdentifier} from "@romejs/ast";
+import {AnyTSEntityName, JSReferenceIdentifier} from "@romejs/ast";
 
-export default function getTSQualifiedBaseFromEntityName(entity: AnyTSEntityName): JSReferenceIdentifier {
+export default function getTSQualifiedBaseFromEntityName(
+	entity: AnyTSEntityName,
+): JSReferenceIdentifier {
 	switch (entity.type) {
 		case "TSQualifiedName":
 			return getTSQualifiedBaseFromEntityName(entity.left);

--- a/packages/@romejs/js-ast-utils/index.ts
+++ b/packages/@romejs/js-ast-utils/index.ts
@@ -44,3 +44,4 @@ export {default as isJSXElement} from "./isJSXElement";
 export {default as tryStaticEvaluation} from "./tryStaticEvaluation";
 export {default as tryStaticEvaluationPath} from "./tryStaticEvaluationPath";
 export {default as resolveIndirection} from "./resolveIndirection";
+export {default as getTSQualifiedBaseFromEntityName} from "./getTSQualifiedBaseFromEntityName";

--- a/packages/@romejs/js-ast-utils/isDeclaration.ts
+++ b/packages/@romejs/js-ast-utils/isDeclaration.ts
@@ -25,7 +25,7 @@ export default function isDeclaration(
 		case "JSExportExternalDeclaration":
 		case "TSDeclareFunction":
 		case "TSEnumDeclaration":
-		case "TSTypeAliasTypeAnnotation":
+		case "TSTypeAlias":
 		case "TSExportAssignment":
 		case "TSImportEqualsDeclaration":
 		case "TSInterfaceDeclaration":

--- a/packages/@romejs/js-parser/parser/modules.ts
+++ b/packages/@romejs/js-parser/parser/modules.ts
@@ -219,7 +219,7 @@ export function parseExport(
 			declaration.type !== "JSFunctionDeclaration" &&
 			declaration.type !== "TSModuleDeclaration" &&
 			declaration.type !== "TSEnumDeclaration" &&
-			declaration.type !== "TSTypeAliasTypeAnnotation" &&
+			declaration.type !== "TSTypeAlias" &&
 			declaration.type !== "TSInterfaceDeclaration" &&
 			declaration.type !== "TSDeclareFunction"
 		) {

--- a/packages/@romejs/js-parser/test-fixtures/experimental/export-extensions/export-with-ts/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/experimental/export-extensions/export-with-ts/input.test.md
@@ -432,7 +432,7 @@ JSRoot {
 					line: 7
 				}
 			}
-			declaration: TSTypeAliasTypeAnnotation {
+			declaration: TSTypeAlias {
 				id: JSBindingIdentifier {
 					name: "G"
 					loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/class/generic/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/class/generic/input.test.md
@@ -124,7 +124,7 @@ JSRoot {
 									}
 								}
 							}
-							default: TSTypeLiteral {
+							default: TSObjectTypeAnnotation {
 								loc: Object {
 									filename: "input.ts"
 									end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/declare/destructure-new-line/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/declare/destructure-new-line/input.test.md
@@ -253,7 +253,7 @@ JSRoot {
 										line: 2
 									}
 								}
-								typeAnnotation: TSTypeLiteral {
+								typeAnnotation: TSObjectTypeAnnotation {
 									loc: Object {
 										filename: "input.ts"
 										end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/declare/destructure/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/declare/destructure/input.test.md
@@ -222,7 +222,7 @@ JSRoot {
 										line: 1
 									}
 								}
-								typeAnnotation: TSTypeLiteral {
+								typeAnnotation: TSObjectTypeAnnotation {
 									loc: Object {
 										filename: "input.ts"
 										end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/export/declare/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/export/declare/input.test.md
@@ -554,7 +554,7 @@ JSRoot {
 									line: 5
 								}
 							}
-							declaration: TSTypeAliasTypeAnnotation {
+							declaration: TSTypeAlias {
 								id: JSBindingIdentifier {
 									name: "T"
 									loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/function/getter-setter/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/function/getter-setter/input.test.md
@@ -222,7 +222,7 @@ JSRoot {
 														line: 2
 													}
 												}
-												typeAnnotation: TSTypeLiteral {
+												typeAnnotation: TSObjectTypeAnnotation {
 													members: Array []
 													loc: Object {
 														filename: "input.ts"
@@ -475,7 +475,7 @@ JSRoot {
 														line: 5
 													}
 												}
-												typeAnnotation: TSTypeLiteral {
+												typeAnnotation: TSObjectTypeAnnotation {
 													members: Array []
 													loc: Object {
 														filename: "input.ts"

--- a/packages/@romejs/js-parser/test-fixtures/typescript/interface/generic/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/interface/generic/input.test.md
@@ -123,7 +123,7 @@ JSRoot {
 								}
 							}
 						}
-						default: TSTypeLiteral {
+						default: TSObjectTypeAnnotation {
 							loc: Object {
 								filename: "input.ts"
 								end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/interface/method-generic/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/interface/method-generic/input.test.md
@@ -219,7 +219,7 @@ JSRoot {
 												}
 											}
 										}
-										default: TSTypeLiteral {
+										default: TSObjectTypeAnnotation {
 											loc: Object {
 												filename: "input.ts"
 												end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/regression/destructuring-in-function-type/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/regression/destructuring-in-function-type/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "MyType"
 				loc: Object {
@@ -225,7 +225,7 @@ JSRoot {
 				}
 			}
 		}
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "AnotherType"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/regression/is-default-export/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/regression/is-default-export/input.test.md
@@ -46,7 +46,7 @@ JSRoot {
 					line: 1
 				}
 			}
-			declaration: TSTypeAliasTypeAnnotation {
+			declaration: TSTypeAlias {
 				id: JSBindingIdentifier {
 					name: "T"
 					loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/scope/no-dupl-decl-type-const/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/scope/no-dupl-decl-type-const/input.test.md
@@ -111,7 +111,7 @@ JSRoot {
 				]
 			}
 		}
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "X"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/scope/no-dupl-decl-type-let/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/scope/no-dupl-decl-type-let/input.test.md
@@ -111,7 +111,7 @@ JSRoot {
 				]
 			}
 		}
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "X"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/scope/no-dupl-decl-type-var/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/scope/no-dupl-decl-type-var/input.test.md
@@ -111,7 +111,7 @@ JSRoot {
 				]
 			}
 		}
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "X"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/tsx/type-arguments/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/tsx/type-arguments/input.test.md
@@ -230,7 +230,7 @@ JSRoot {
 				}
 			}
 		}
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "A"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/declare/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/declare/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/export/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/export/input.test.md
@@ -65,7 +65,7 @@ JSRoot {
 					line: 1
 				}
 			}
-			declaration: TSTypeAliasTypeAnnotation {
+			declaration: TSTypeAlias {
 				id: JSBindingIdentifier {
 					name: "T"
 					loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/generic-complex/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/generic-complex/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T"
 				loc: Object {
@@ -188,7 +188,7 @@ JSRoot {
 								}
 							}
 						}
-						default: TSTypeLiteral {
+						default: TSObjectTypeAnnotation {
 							loc: Object {
 								filename: "input.ts"
 								end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/generic/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/generic/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/plain/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/type-alias/plain/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/conditional-infer/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/conditional-infer/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "Element"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/object-shorthand/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/object-shorthand/input.test.md
@@ -309,7 +309,7 @@ JSRoot {
 															line: 2
 														}
 													}
-													constraint: TSTypeLiteral {
+													constraint: TSObjectTypeAnnotation {
 														loc: Object {
 															filename: "input.ts"
 															end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/parenthesized/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/parenthesized/input.test.md
@@ -30,7 +30,7 @@ JSRoot {
 		}
 	}
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T"
 				loc: Object {
@@ -76,7 +76,7 @@ JSRoot {
 						line: 1
 					}
 				}
-				typeAnnotation: TSTypeLiteral {
+				typeAnnotation: TSObjectTypeAnnotation {
 					members: Array []
 					loc: Object {
 						filename: "input.ts"

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-1/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-1/input.test.md
@@ -72,7 +72,7 @@ JSRoot {
 		}
 	]
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T30"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-2/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-2/input.test.md
@@ -72,7 +72,7 @@ JSRoot {
 		}
 	]
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T31"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-3/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-3/input.test.md
@@ -72,7 +72,7 @@ JSRoot {
 		}
 	]
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T32"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-4/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/read-only-4/input.test.md
@@ -72,7 +72,7 @@ JSRoot {
 		}
 	]
 	body: Array [
-		TSTypeAliasTypeAnnotation {
+		TSTypeAlias {
 			id: JSBindingIdentifier {
 				name: "T33"
 				loc: Object {

--- a/packages/@romejs/js-parser/test-fixtures/typescript/types/type-literal/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/typescript/types/type-literal/input.test.md
@@ -111,7 +111,7 @@ JSRoot {
 										line: 1
 									}
 								}
-								typeAnnotation: TSTypeLiteral {
+								typeAnnotation: TSObjectTypeAnnotation {
 									loc: Object {
 										filename: "input.ts"
 										end: Object {

--- a/packages/@romejs/js-parser/tokenizer/state.ts
+++ b/packages/@romejs/js-parser/tokenizer/state.ts
@@ -20,6 +20,7 @@ import {
 	ob1Number1,
 } from "@romejs/ob1";
 
+// rome-ignore lint/js/noUnusedVariables
 type Scopes = {[K in ScopeType]?: Array<unknown>};
 
 export type State = {

--- a/packages/@romejs/messages/index.ts
+++ b/packages/@romejs/messages/index.ts
@@ -20,6 +20,7 @@ type MessagesShape = {
 
 type Factory = (...args: Array<unknown>) => string;
 
+// rome-ignore lint/js/noUnusedVariables
 type FactoryObject<Messages extends MessagesShape> = {
 	[P in keyof Messages]: Factory
 };

--- a/packages/@romejs/project/types.ts
+++ b/packages/@romejs/project/types.ts
@@ -101,10 +101,8 @@ type ProjectConfigJSONPropertyReducer<Type> = Type extends AbsoluteFilePath
 					? ProjectConfigJSONObjectReducer<Type>
 					: Type;
 
-type ProjectConfigJSONObjectReducer<Object> = {
-	[PropertyKey in keyof Object]: ProjectConfigJSONPropertyReducer<
-		Object[PropertyKey]
-	>
+type ProjectConfigJSONObjectReducer<Obj> = {
+	[PropertyKey in keyof Obj]: ProjectConfigJSONPropertyReducer<Obj[PropertyKey]>
 };
 
 // Base of a project config without any objects

--- a/packages/@romejs/string-markup/grid/ansi.ts
+++ b/packages/@romejs/string-markup/grid/ansi.ts
@@ -89,6 +89,7 @@ type TokenFormat = {
 	fontStyle?: FontStyle;
 };
 
+// rome-ignore lint/js/noUnusedVariables
 type TokenFormats = {[type in MarkupTokenType]?: TokenFormat};
 
 const tokenTypeToScope: Dict<MarkupTokenType> = {

--- a/website/src/docs/check/rules/index.md
+++ b/website/src/docs/check/rules/index.md
@@ -133,4 +133,5 @@ showHero: false
 | Rule | Description |
 | ------------- | ------------- |
 | no-explicit-any |  |
+| prefer-interfaces |  |
 


### PR DESCRIPTION
So I implemented it but it's not enabled. When ran over Rome it breaks a ton of stuff where we try and expect JSON. 

The root of why is this TypeScript problem microsoft/TypeScript#15300 which can be summarized as:

```
interface A {
  a: number;
}

const a: A = {a: 1};
const b: {[key: string]: number} = a;
```

Technically this should pass but TypeScript does not let you pass an interface object into an object index.

We use an object index to represent an object that has valid-JSON fields.

I'm not really sure how to resolve this. I guess we'll leave it disabled until potentially that issue is resolved. Having it as an option would mean suppressing hundreds of locations in Rome itself. Which is pointless since a lot of stuff goes over the bridge making this not a reliable rule.