### PR TITLE
Fixed link to the check command

### DIFF
--- a/website/src/_includes/layouts/base.njk
+++ b/website/src/_includes/layouts/base.njk
@@ -75,7 +75,7 @@
           <h2 id="site-navigation">Components</h2>
           <ul>
             <li>
-              <a href="{{ '/docs/lint' | url }}">Linting</a>
+              <a href="{{ '/docs/check' | url }}">Linting</a>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
The "Linting" link on the side is giving a 404 because we changed the command from `lint` to `check` bug I forgot to update the href of the navigation bar.

This PR fixes that

