### PR TITLE
Prevent requestWorkerFormat during LSP project init

### DIFF
--- a/packages/@romejs/core/server/lsp/LSPServer.ts
+++ b/packages/@romejs/core/server/lsp/LSPServer.ts
@@ -525,6 +525,14 @@ export default class LSPServer {
 					return null;
 				}
 
+				if (!this.lintSessions.has(project.folder)) {
+					this.logMessage(
+						path,
+						"Formatting unavailable while initializing project.",
+					);
+					return null;
+				}
+
 				const {value, diagnostics} = await catchDiagnostics(async () => {
 					return this.request.requestWorkerFormat(path, {});
 				});


### PR DESCRIPTION
This is a quick fix to prevent the LSP server from sometimes hanging when someone attempts to format a document while the project’s initial `Linter#watch` is running. I think I'll be able to implement a better solution once I've spent some more time working with the LSP server.

Closes #651 