### PR TITLE
Fix Client#end causing issues with daemon

### DIFF
--- a/packages/@romejs/core/server/Server.ts
+++ b/packages/@romejs/core/server/Server.ts
@@ -481,6 +481,10 @@ export default class Server {
 		// We should remove everything that has an external dependency like a socket or process
 		await this.endEvent.callOptional();
 		this.workerManager.end();
+
+		if (this.options.dedicated) {
+			process.exit();
+		}
 	}
 
 	async attachToBridge(bridge: ServerBridge): Promise<ServerClient> {


### PR DESCRIPTION
I can't remember why I did it but previously called `client.end()` would cause the server to be shutdown. This was fine when the server was running inside the process, but if it was ran with a connected daemon then it would shutdown the server but the process would still hang around.

This PR makes it so that `client.end()`, when connected to daemon, just kills the socket. There is now a separate `client.shutdownServer`.

NOTE: If you want to communicate with the daemon then you CANNOT run `scripts/dev-rome` or else it will encounter a race condition where during the daemon tries to start a worker but we've cleared `/tmp/rome-dev` so it will not be able to fork a worker.

```
scripts/dev-rome start
node $TMPDIR/rome-dev/index.js status
```
