### PR TITLE
Don't let vendor-rome connect to dev-rome daemon and skip trunk build if dev daemon running

### DIFF
--- a/packages/@romejs/core/common/constants.ts
+++ b/packages/@romejs/core/common/constants.ts
@@ -25,7 +25,13 @@ export const MAX_WORKER_BYTES_BEFORE_ADD = 1 * MEGABYTE;
 const CPU_COUNT: number = os.cpus().length;
 export const MAX_WORKER_COUNT = Math.min(CPU_COUNT, 4);
 
-export const VERSION = String(packageJson.version);
+export let VERSION = String(packageJson.version);
+
+// Vendor Rome and Trunk Rome could have the same version number if there was no release in between
+// Ensure they are properly namespaced to avoid having daemon socket conflicts
+if (process.env.ROME_DEV === "1") {
+	VERSION += "-dev";
+}
 
 export const SOCKET_PATH = TEMP_PATH.append(`rome-${VERSION}.sock`);
 

--- a/scripts/assert-generated
+++ b/scripts/assert-generated
@@ -23,17 +23,18 @@ const filteredWrittenFiles = writtenFiles.filter(function(file){
 });
 
 // Autofix them
-execDev(["check", ...filteredWrittenFiles, "--apply"]);
+execDev(["check", ...filteredWrittenFiles, "--apply"]).finally(() => {
+	// Check that `git status` is fine
+	const out = child_process
+		.spawnSync("git", ["ls-files", "-m"])
+		.stdout.toString();
+	if (out !== "") {
+		console.error("Modified files:");
+		console.error(out);
+		console.log();
+		console.log("To fix this run `node scripts/assert-generated` and commit the results");
+		console.log();
+		process.exit(1);
+	}
+});
 
-// Check that `git status` is fine
-const out = child_process
-	.spawnSync("git", ["ls-files", "-m"])
-	.stdout.toString();
-if (out !== "") {
-	console.error("Modified files:");
-	console.error(out);
-	console.log();
-	console.log("To fix this run `node scripts/assert-generated` and commit the results");
-	console.log();
-	process.exit(1);
-}

--- a/scripts/run-vscode-extension
+++ b/scripts/run-vscode-extension
@@ -14,19 +14,23 @@ const os = require("os");
 
 const outFolder = path.join(os.tmpdir(), "rome-vscode-dev");
 
-buildTrunk();
+async function main() {
+  await buildTrunk();
 
-heading("Bundling Extension");
-execDev([
-  "bundle",
-  "@romejs-integration/vscode",
-  outFolder,
-]);
+  heading("Bundling Extension");
+  await execDev([
+    "bundle",
+    "@romejs-integration/vscode",
+    outFolder,
+  ]);
+  
+  heading("Running VSCode");
+  exec("code", [
+    "--extensionDevelopmentPath",
+    outFolder,
+    "--disable-extensions",
+    ...argv,
+  ]);
+}
 
-heading("Running VSCode");
-exec("code", [
-  "--extensionDevelopmentPath",
-  outFolder,
-  "--disable-extensions",
-  ...argv,
-]);
+main();


### PR DESCRIPTION
This makes local daemon development much nicer by making `dev-rome` reuse an old build if a daemon is running. The CLI and daemon build need to match exactly or else you'll get really weird bugs.

This now allows the following commands to be executed one after the other:

```
$ scripts/dev-rome start
$ scripts/dev-rome status
$ scripts/dev-rome stop
```

![Screen Shot 2020-07-01 at 11 20 33 PM](https://user-images.githubusercontent.com/853712/86323412-a4865180-bbf1-11ea-853b-225ca7daeae3.png)
