### PR TITLE
Fix watchFilesFromArgs flush timeout

### DIFF
--- a/packages/@romejs/core/server/ServerRequest.ts
+++ b/packages/@romejs/core/server/ServerRequest.ts
@@ -601,11 +601,11 @@ export default class ServerRequest {
 		let pendingPaths = new AbsoluteFilePathSet();
 
 		async function flush(initial: boolean) {
+			timeout = undefined;
+
 			if (!initial && pendingPaths.size === 0) {
 				return;
 			}
-
-			timeout = undefined;
 
 			const paths = pendingPaths;
 			pendingPaths = new AbsoluteFilePathSet();


### PR DESCRIPTION
This fixes `ServerRequest#watchFilesFromArgs` so that it doesn't stop working if there's ever a `refreshFileEvent` called with a path that it's ignoring.

Previously, `flush()` would return before setting `timeout = undefined` when there were no pending paths,  so the `refreshFileEvent` subscription would never be able to set a new `flush` timeout.

This is one of the reasons that the LSP server would suddenly stop publishing diagnostics.