### PR TITLE
HTML ast nodes

### DIFF
--- a/packages/@romejs/ast/html/attributes/HTMLAriaAttribute.ts
+++ b/packages/@romejs/ast/html/attributes/HTMLAriaAttribute.ts
@@ -1,0 +1,16 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+
+// aria-checked
+export type HTMLAriaAttribute = NodeBaseWithComments & {
+	type: "HTMLAriaAttribute";
+	value: string;
+};
+
+export const htmlAriaAttribute = createBuilder<HTMLAriaAttribute>(
+	"HTMLAriaAttribute",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/html/attributes/HTMLAttribute.ts
+++ b/packages/@romejs/ast/html/attributes/HTMLAttribute.ts
@@ -1,0 +1,16 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+
+// class="something"
+export type HTMLAttribute = NodeBaseWithComments & {
+	type: "HTMLAttribute";
+	value: string;
+};
+
+export const htmlAttribute = createBuilder<HTMLAttribute>(
+	"HTMLAttribute",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/html/attributes/HTMLDataAttribute.ts
+++ b/packages/@romejs/ast/html/attributes/HTMLDataAttribute.ts
@@ -1,0 +1,16 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+
+// data-open
+export type HTMLDataAttribute = NodeBaseWithComments & {
+	type: "HTMLDataAttribute";
+	value: string;
+};
+
+export const htmlDataAttribute = createBuilder<HTMLDataAttribute>(
+	"HTMLDataAttribute",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/html/core/HTMLCommentBlock.ts
+++ b/packages/@romejs/ast/html/core/HTMLCommentBlock.ts
@@ -1,0 +1,15 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+
+// <!-- -->
+export type HTMLCommentBlock = NodeBaseWithComments & {
+	type: "HTMLCommentBlock";
+};
+
+export const htmlCommentBlock = createBuilder<HTMLCommentBlock>(
+	"HTMLCommentBlock",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/html/core/HTMLRoot.ts
+++ b/packages/@romejs/ast/html/core/HTMLRoot.ts
@@ -1,0 +1,20 @@
+import {NodeBaseWithComments, RootBase} from "../../index";
+import {createBuilder} from "../../utils";
+import {HTMLAnyNode} from "@romejs/ast/html/unions";
+
+export type HTMLRoot = NodeBaseWithComments &
+	RootBase & {
+		type: "HTMLRoot";
+		body: Array<HTMLAnyNode>;
+	};
+
+export const htmlRoot = createBuilder<HTMLRoot>(
+	"HTMLRoot",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			body: true,
+			comments: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/html/core/HTMLText.ts
+++ b/packages/@romejs/ast/html/core/HTMLText.ts
@@ -1,0 +1,15 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+
+export type HTMLText = NodeBaseWithComments & {
+	type: "HTMLText";
+	value: string;
+};
+
+export const htmlText = createBuilder<HTMLText>(
+	"HTMLText",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/html/tags/HTMLDoctypeTag.ts
+++ b/packages/@romejs/ast/html/tags/HTMLDoctypeTag.ts
@@ -1,0 +1,18 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+import {AnyHTMLAttribute} from "@romejs/ast/html/unions";
+
+export type HTMLDoctypeTag = NodeBaseWithComments & {
+	type: "HTMLDoctypeTag";
+	attributes: Array<AnyHTMLAttribute>;
+};
+
+export const htmlDoctypeTag = createBuilder<HTMLDoctypeTag>(
+	"HTMLDoctypeTag",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			attributes: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/html/tags/HTMLTag.ts
+++ b/packages/@romejs/ast/html/tags/HTMLTag.ts
@@ -1,0 +1,21 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+import {AnyHTMLAttribute} from "@romejs/ast/html/unions";
+
+export type HTMLTag = NodeBaseWithComments & {
+	type: "HTMLTag";
+	attributes: Array<AnyHTMLAttribute>;
+	kind: "self-closing" | "open";
+	childNodes: Array<HTMLTag>;
+};
+
+export const htmlTag = createBuilder<HTMLTag>(
+	"HTMLTag",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			attributes: true,
+			childNodes: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/html/tags/HTMLXmlTag.ts
+++ b/packages/@romejs/ast/html/tags/HTMLXmlTag.ts
@@ -1,0 +1,14 @@
+import {NodeBaseWithComments} from "../../index";
+import {createBuilder} from "../../utils";
+
+export type HTMLXmlTag = NodeBaseWithComments & {
+	type: "HTMLXmlTag";
+};
+
+export const htmlXmlTag = createBuilder<HTMLXmlTag>(
+	"HTMLXmlTag",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/html/unions.ts
+++ b/packages/@romejs/ast/html/unions.ts
@@ -1,0 +1,13 @@
+import * as n from "@romejs/ast";
+
+export type HTMLAnyNode =
+	| n.HTMLCommentBlock
+	| n.HTMLDoctypeTag
+	| n.HTMLTag
+	| n.HTMLXmlTag
+	| n.HTMLText;
+
+export type AnyHTMLAttribute =
+	| n.HTMLAriaAttribute
+	| n.HTMLAttribute
+	| n.HTMLDataAttribute;

--- a/packages/@romejs/ast/index.ts
+++ b/packages/@romejs/ast/index.ts
@@ -60,6 +60,15 @@ export * from "./css/types/CSSTimeType";
 export * from "./css/types/CSSTransformFunctionType";
 export * from "./css/types/CSSURLType";
 export * from "./css/at-rules/CSSViewportAtStatement";
+export * from "./html/attributes/HTMLAriaAttribute";
+export * from "./html/attributes/HTMLAttribute";
+export * from "./html/core/HTMLCommentBlock";
+export * from "./html/attributes/HTMLDataAttribute";
+export * from "./html/tags/HTMLDoctypeTag";
+export * from "./html/core/HTMLRoot";
+export * from "./html/tags/HTMLTag";
+export * from "./html/core/HTMLText";
+export * from "./html/tags/HTMLXmlTag";
 export * from "./js/temp/JSAmbiguousFlowTypeCastExpression";
 export * from "./js/expressions/JSArrayExpression";
 export * from "./js/auxiliary/JSArrayHole";
@@ -318,6 +327,15 @@ export type AnyNode =
 	| n.CSSTransformFunctionType
 	| n.CSSURLType
 	| n.CSSViewportAtStatement
+	| n.HTMLAriaAttribute
+	| n.HTMLAttribute
+	| n.HTMLCommentBlock
+	| n.HTMLDataAttribute
+	| n.HTMLDoctypeTag
+	| n.HTMLRoot
+	| n.HTMLTag
+	| n.HTMLText
+	| n.HTMLXmlTag
 	| n.JSAmbiguousFlowTypeCastExpression
 	| n.JSArrayExpression
 	| n.JSArrayHole

--- a/packages/@romejs/formatter/builders/html/attributes/HTMLAriaAttribute.ts
+++ b/packages/@romejs/formatter/builders/html/attributes/HTMLAriaAttribute.ts
@@ -1,0 +1,9 @@
+import {HTMLAriaAttribute} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLAriaAttribute(
+	builder: Builder,
+	node: HTMLAriaAttribute,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/attributes/HTMLAttribute.ts
+++ b/packages/@romejs/formatter/builders/html/attributes/HTMLAttribute.ts
@@ -1,0 +1,9 @@
+import {HTMLAttribute} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLAttribute(
+	builder: Builder,
+	node: HTMLAttribute,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/attributes/HTMLDataAttribute.ts
+++ b/packages/@romejs/formatter/builders/html/attributes/HTMLDataAttribute.ts
@@ -1,0 +1,9 @@
+import {HTMLDataAttribute} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLDataAttribute(
+	builder: Builder,
+	node: HTMLDataAttribute,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/core/HTMLCommentBlock.ts
+++ b/packages/@romejs/formatter/builders/html/core/HTMLCommentBlock.ts
@@ -1,0 +1,9 @@
+import {HTMLCommentBlock} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLCommentBlock(
+	builder: Builder,
+	node: HTMLCommentBlock,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/core/HTMLRoot.ts
+++ b/packages/@romejs/formatter/builders/html/core/HTMLRoot.ts
@@ -1,0 +1,6 @@
+import {HTMLRoot} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLRoot(builder: Builder, node: HTMLRoot): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/core/HTMLText.ts
+++ b/packages/@romejs/formatter/builders/html/core/HTMLText.ts
@@ -1,0 +1,6 @@
+import {HTMLText} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLText(builder: Builder, node: HTMLText): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/tags/HTMLDoctypeTag.ts
+++ b/packages/@romejs/formatter/builders/html/tags/HTMLDoctypeTag.ts
@@ -1,0 +1,9 @@
+import {HTMLDoctypeTag} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLDoctypeTag(
+	builder: Builder,
+	node: HTMLDoctypeTag,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/tags/HTMLTag.ts
+++ b/packages/@romejs/formatter/builders/html/tags/HTMLTag.ts
@@ -1,0 +1,6 @@
+import {HTMLTag} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLTag(builder: Builder, node: HTMLTag): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/html/tags/HTMLXmlTag.ts
+++ b/packages/@romejs/formatter/builders/html/tags/HTMLXmlTag.ts
@@ -1,0 +1,6 @@
+import {HTMLXmlTag} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function HTMLXmlTag(builder: Builder, node: HTMLXmlTag): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/index.ts
+++ b/packages/@romejs/formatter/builders/index.ts
@@ -164,6 +164,33 @@ builders.set("CSSURLType", CSSURLType);
 import CSSViewportAtStatement from "./css/at-rules/CSSViewportAtStatement";
 builders.set("CSSViewportAtStatement", CSSViewportAtStatement);
 
+import HTMLAriaAttribute from "./html/attributes/HTMLAriaAttribute";
+builders.set("HTMLAriaAttribute", HTMLAriaAttribute);
+
+import HTMLAttribute from "./html/attributes/HTMLAttribute";
+builders.set("HTMLAttribute", HTMLAttribute);
+
+import HTMLCommentBlock from "./html/core/HTMLCommentBlock";
+builders.set("HTMLCommentBlock", HTMLCommentBlock);
+
+import HTMLDataAttribute from "./html/attributes/HTMLDataAttribute";
+builders.set("HTMLDataAttribute", HTMLDataAttribute);
+
+import HTMLDoctypeTag from "./html/tags/HTMLDoctypeTag";
+builders.set("HTMLDoctypeTag", HTMLDoctypeTag);
+
+import HTMLRoot from "./html/core/HTMLRoot";
+builders.set("HTMLRoot", HTMLRoot);
+
+import HTMLTag from "./html/tags/HTMLTag";
+builders.set("HTMLTag", HTMLTag);
+
+import HTMLText from "./html/core/HTMLText";
+builders.set("HTMLText", HTMLText);
+
+import HTMLXmlTag from "./html/tags/HTMLXmlTag";
+builders.set("HTMLXmlTag", HTMLXmlTag);
+
 import JSAmbiguousFlowTypeCastExpression from "./js/temp/JSAmbiguousFlowTypeCastExpression";
 builders.set(
 	"JSAmbiguousFlowTypeCastExpression",


### PR DESCRIPTION
This PR creates the initial HTML AST nodes.

For now I just created few nodes that should describe the HTML tree but probably I missed something, so I'd like to have some feedback before actually merging it.

I tried to divide the nodes in `core`, `tags` and `attributes`
- core => root and comments
- tags => normal tags, xml tag (old, should we support it? e.g. `<?xml version="1.0" ?>`) and doctype tag (e.g. `<!DOCTYPE html>`)
- attributes => aria attributes, data attributes and attributes (class, style, etc.)

Is there something that I am missing or some information we'd want to have?

cc @sebmck 