### PR TITLE
Minor: Replaced broken Code of Conduct link in the footer section

### DIFF
--- a/website/src/_includes/layouts/sections/footer.njk
+++ b/website/src/_includes/layouts/sections/footer.njk
@@ -8,7 +8,7 @@
 					<h2 id="community-navigation">Community</h2>
 					<ul>
 						<li>
-							<a href="https://github.com/romejs/rome/blob/main/.github/CODE_OF_CONDUCT.md">Code of Conduct</a>
+							<a href="https://github.com/romejs/rome/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>
 						</li>
 						<li>
 							<a href="https://discord.gg/9WxHa5d">Discord</a>


### PR DESCRIPTION
Replaced broken "Code of Conduct" link in the footer section with the current working link