### PR TITLE
Fix `rome --help` and add test case

### DIFF
--- a/packages/@romejs/cli-flags/Parser.test.md
+++ b/packages/@romejs/cli-flags/Parser.test.md
@@ -46,6 +46,62 @@
 
 ```
 
+## `command required with no command but with --help flag`
+
+### `flags`
+
+```javascript
+Object {}
+```
+
+### `help`
+
+```
+
+ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  $ test [flags]
+
+ Global Flags ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  --generate-autocomplete <shell> Generate a shell autocomplete (values: fish|bash)
+                           --help Show this help screen
+
+ Commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  - bar 
+  - foo 
+
+  ℹ To view help for a specific command run
+  $ test command_name --help
+
+
+```
+
+### `output`
+
+```
+
+ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  $ test [flags]
+
+ Global Flags ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  --generate-autocomplete <shell> Generate a shell autocomplete (values: fish|bash)
+                           --help Show this help screen
+
+ Commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  - bar 
+  - foo 
+
+  ℹ To view help for a specific command run
+  $ test command_name --help
+
+
+```
+
 ## `command required with wrong command`
 
 ### `help`
@@ -63,6 +119,8 @@
 
  Commands ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+  - foobar 
+
   ℹ To view help for a specific command run
   $ test command_name --help
 
@@ -79,6 +137,10 @@
 
     $ test foo foo 
            ^^^
+
+  ℹ Did you mean foobar?
+
+  + foobar
 
   ℹ To see available commands run
 

--- a/packages/@romejs/cli-flags/Parser.ts
+++ b/packages/@romejs/cli-flags/Parser.ts
@@ -432,7 +432,7 @@ export default class Parser<T> {
 
 			this.currentCommand = undefined;
 
-			if (this.opts.commandRequired) {
+			if (this.opts.commandRequired && !shouldShowHelp) {
 				this.commandRequired(definedCommand !== undefined, flagsConsumer);
 			}
 

--- a/packages/@romejs/cli-flags/Parser.ts
+++ b/packages/@romejs/cli-flags/Parser.ts
@@ -68,6 +68,7 @@ export type ParserOptions<T> = {
 	description?: string;
 	version?: string;
 	ignoreFlags?: Array<string>;
+	noProcessExit?: boolean;
 	commandRequired?: boolean;
 	commandSuggestions?: Dict<{
 		commandName: string;
@@ -383,7 +384,7 @@ export default class Parser<T> {
 			).asBoolean(false);
 			if (shouldDisplayVersion) {
 				this.reporter.logAll(version);
-				process.exit(0);
+				this.exit(0);
 			}
 		}
 
@@ -398,7 +399,7 @@ export default class Parser<T> {
 		).asStringSetOrVoid(["fish", "bash"]);
 		if (generateAutocomplete !== undefined) {
 			await this.generateAutocomplete(generateAutocomplete);
-			process.exit(0);
+			this.exit(0);
 		}
 
 		// Show help for --help
@@ -444,7 +445,7 @@ export default class Parser<T> {
 			await this.showHelp(
 				definedCommand === undefined ? undefined : definedCommand.command,
 			);
-			process.exit(1);
+			this.exit(1);
 		}
 
 		if (definedCommand !== undefined) {
@@ -961,6 +962,12 @@ export default class Parser<T> {
 		this.currentCommand = undefined;
 
 		return flags;
+	}
+
+	exit(code: number) {
+		if (!this.opts.noProcessExit) {
+			process.exit(code);
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a `noProcessExit` option to Parser so that the `--help` test doesn't kill the test worker.

Adds a `preInit` callback to the `testParser` utility so that commands can be added before `parser.init()`

Closes #686