### PR TITLE
Fix overlap of stacked inline code elements

### DIFF
--- a/website/src/styles/_global.scss
+++ b/website/src/styles/_global.scss
@@ -29,7 +29,7 @@ code {
   font-family: "Fira Code", monospace !important;
   tab-size: 2 !important;
   background-color: rgba(0, 0, 0, 0.08);
-  padding: 5px;
+  padding: 0 5px;
 }
 
 p {


### PR DESCRIPTION
currently, the padding in inline code elements causes stacked code spans to overlap:
![Screenshot_2020-07-03 An experimental JavaScript toolchain Rome](https://user-images.githubusercontent.com/11270438/86494615-7d678580-bd93-11ea-9d9b-d38c664e55b7.png)

this PR fixes the styles to fix this:
![Screenshot_2020-07-03 An experimental JavaScript toolchain Rome(1)](https://user-images.githubusercontent.com/11270438/86494626-89ebde00-bd93-11ea-96fd-b9af3bfa6007.png)
