### PR TITLE
Add noRetry option to wrapRequestDiagnostic

### DIFF
--- a/packages/@romejs/core/server/lsp/LSPServer.ts
+++ b/packages/@romejs/core/server/lsp/LSPServer.ts
@@ -525,14 +525,6 @@ export default class LSPServer {
 					return null;
 				}
 
-				if (!this.lintSessions.has(project.folder)) {
-					this.logMessage(
-						path,
-						"Formatting unavailable while initializing project.",
-					);
-					return null;
-				}
-
 				const {value, diagnostics} = await catchDiagnostics(async () => {
 					return this.request.requestWorkerFormat(path, {});
 				});


### PR DESCRIPTION
This fixes a problem with `requestWorkerUpdateBuffer` and `requestWorkerClearBuffer`. They both cause a file's (fake) `mtime` to change, but `wrapRequestDiagnostic` normally retries requests if the `mtime` for a file changes while a request is processing.

For reasons that I didn't fully explore, this usually resulted in a nondeterministic number of retries as opposed to an infinite loop, but I think this was the main problem causing the LSP server to hang in some situations.

This also removes the "quick fix" for formatting requests because it's no longer necessary.