### PR TITLE
Add timeout to Server#writeFiles

### DIFF
--- a/packages/@romejs/core/server/Server.ts
+++ b/packages/@romejs/core/server/Server.ts
@@ -441,23 +441,25 @@ export default class Server {
 
 			// Protects against file events not being emitted and causing hanging
 			const timeoutPromise = new Promise((resolve, reject) => {
-				const timeout = setTimeout(() => {
-					const lines = ["File events should have been emitted within a second. Did not receive an event for:"];
-					for (const path of paths) {
-						lines.push(` - ${path.join()}`);
-					}
-					reject(new Error(lines.join("\n")));
-				}, 1000);
-	
+				const timeout = setTimeout(
+					() => {
+						const lines = [
+							"File events should have been emitted within a second. Did not receive an event for:",
+						];
+						for (const path of paths) {
+							lines.push(` - ${path.join()}`);
+						}
+						reject(new Error(lines.join("\n")));
+					},
+					1_000,
+				);
+
 				teardowns.push(async () => {
 					clearTimeout(timeout);
 				});
 			});
 
-			await Promise.race([
-				waitRefresh,
-				timeoutPromise,
-			]);
+			await Promise.race([waitRefresh, timeoutPromise]);
 		} finally {
 			for (const teardown of teardowns) {
 				await teardown();

--- a/packages/@romejs/core/server/Server.ts
+++ b/packages/@romejs/core/server/Server.ts
@@ -442,7 +442,11 @@ export default class Server {
 			// Protects against file events not being emitted and causing hanging
 			const timeoutPromise = new Promise((resolve, reject) => {
 				const timeout = setTimeout(() => {
-					reject(new Error("File events should have been emitted within a second"));
+					const lines = ["File events should have been emitted within a second. Did not receive an event for:"];
+					for (const path of paths) {
+						lines.push(` - ${path.join()}`);
+					}
+					reject(new Error(lines.join("\n")));
 				}, 1000);
 	
 				teardowns.push(async () => {

--- a/packages/@romejs/core/server/Server.ts
+++ b/packages/@romejs/core/server/Server.ts
@@ -421,7 +421,7 @@ export default class Server {
 			this.logger.list(Array.from(paths, (path) => path.toMarkup()));
 		}
 
-		let teardown: undefined | (() => Promise<void>);
+		const teardowns: Array<() => Promise<void>> = [];
 
 		const waitRefresh = new Promise((resolve) => {
 			const sub = this.refreshFileEvent.subscribe((path) => {
@@ -431,7 +431,7 @@ export default class Server {
 				}
 			});
 
-			teardown = () => sub.unsubscribe();
+			teardowns.push(() => sub.unsubscribe());
 		});
 
 		try {
@@ -439,9 +439,23 @@ export default class Server {
 				await writeFile(path, content);
 			}
 
-			await waitRefresh;
+			// Protects against file events not being emitted and causing hanging
+			const timeoutPromise = new Promise((resolve, reject) => {
+				const timeout = setTimeout(() => {
+					reject(new Error("File events should have been emitted within a second"));
+				}, 1000);
+	
+				teardowns.push(async () => {
+					clearTimeout(timeout);
+				});
+			});
+
+			await Promise.race([
+				waitRefresh,
+				timeoutPromise,
+			]);
 		} finally {
-			if (teardown !== undefined) {
+			for (const teardown of teardowns) {
 				await teardown();
 			}
 		}


### PR DESCRIPTION
I think this could be the cause of the macOS CI timeout we see pretty often. @yassere flagged this before in a previous review but I never bothered to add this. We'll see what happens.