### PR TITLE
feat: CSS tokenizer

### DIFF
--- a/packages/@romejs/css-parser/index.ts
+++ b/packages/@romejs/css-parser/index.ts
@@ -1,0 +1,7 @@
+import {TokenValues} from "@romejs/parser-core";
+import {CSSParserOptions, Tokens} from "./types";
+import {createCSSParser} from "./parse";
+
+export function tokenizeCSS(opts: CSSParserOptions): Array<TokenValues<Tokens>> {
+	return createCSSParser(opts).tokenizeAll();
+}

--- a/packages/@romejs/css-parser/parse.test.ts
+++ b/packages/@romejs/css-parser/parse.test.ts
@@ -1,0 +1,808 @@
+import "@romejs/core";
+import {test} from "rome";
+import {tokenizeCSS} from ".";
+
+test(
+	"whitespace",
+	(t) => {
+		const results = [
+			{
+				type: "Whitespace",
+				end: 2,
+				start: 0,
+			},
+			{
+				type: "AtKeyword",
+				value: "import",
+				end: 9,
+				start: 2,
+			},
+			{
+				type: "EOF",
+				end: 9,
+				start: 9,
+			},
+		];
+		t.looksLike(tokenizeCSS({input: "  @import"}), results);
+		t.looksLike(tokenizeCSS({input: "\t\t@import"}), results);
+		t.looksLike(tokenizeCSS({input: "\n\n@import"}), results);
+	},
+);
+
+test(
+	"quote",
+	(t) => {
+		function getResults(index: number) {
+			return [
+				{
+					type: "String",
+					value: "foo",
+					end: index,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: index,
+					start: index,
+				},
+			];
+		}
+		t.looksLike(tokenizeCSS({input: '"foo"'}), getResults(5));
+		t.looksLike(tokenizeCSS({input: '"fo\\6f"'}), getResults(7));
+		t.looksLike(
+			tokenizeCSS({input: '"fo\n"'}),
+			[
+				{
+					type: "BadString",
+					end: 3,
+					start: 0,
+				},
+				{
+					type: "Whitespace",
+					end: 4,
+					start: 3,
+				},
+				{
+					type: "String",
+					value: "",
+					end: 5,
+					start: 4,
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"apostrophe",
+	(t) => {
+		function getResults(index: number) {
+			return [
+				{
+					type: "String",
+					value: "foo",
+					end: index,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: index,
+					start: index,
+				},
+			];
+		}
+		t.looksLike(tokenizeCSS({input: "'foo'"}), getResults(5));
+		t.looksLike(tokenizeCSS({input: "'fo\\6f'"}), getResults(7));
+		t.looksLike(
+			tokenizeCSS({input: "'fo\n'"}),
+			[
+				{
+					type: "BadString",
+					end: 3,
+					start: 0,
+				},
+				{
+					type: "Whitespace",
+					end: 4,
+					start: 3,
+				},
+				{
+					type: "String",
+					value: "",
+					end: 5,
+					start: 4,
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"hash",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "#foo"}),
+			[
+				{
+					type: "Hash",
+					value: "foo",
+					hashType: "id",
+					end: 4,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 4,
+					start: 4,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "# "}),
+			[
+				{
+					type: "Delim",
+					value: "#",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "Whitespace",
+					end: 2,
+					start: 1,
+				},
+				{
+					type: "EOF",
+					end: 2,
+					start: 2,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "#\\66oo"}),
+			[
+				{
+					type: "Hash",
+					value: "foo",
+					hashType: "id",
+					end: 6,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 6,
+					start: 6,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"left-paren",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "("}),
+			[
+				{
+					type: "LeftParen",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"right-paren",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "("}),
+			[
+				{
+					type: "LeftParen",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"+",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "+123"}),
+			[
+				{
+					type: "Number",
+					value: 123,
+					end: 4,
+					start: 0,
+					numberType: "integer",
+				},
+				{
+					type: "EOF",
+					end: 4,
+					start: 4,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "+0.123"}),
+			[
+				{
+					type: "Number",
+					value: 0.123,
+					end: 6,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 6,
+					start: 6,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "+.123"}),
+			[
+				{
+					type: "Number",
+					value: 0.123,
+					end: 5,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "+10e3"}),
+			[
+				{
+					type: "Number",
+					value: 10_000,
+					end: 5,
+					start: 0,
+					numberType: "integer",
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "+3.4e-2"}),
+			[
+				{
+					type: "Number",
+					value: 0.034,
+					end: 7,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 7,
+					start: 7,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"comma",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: ","}),
+			[
+				{
+					type: "Comma",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"-",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "-foo"}),
+			[
+				{
+					type: "Ident",
+					value: "-foo",
+					end: 4,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 4,
+					start: 4,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-123"}),
+			[
+				{
+					type: "Number",
+					value: -123,
+					end: 4,
+					start: 0,
+					numberType: "integer",
+				},
+				{
+					type: "EOF",
+					end: 4,
+					start: 4,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-0.123"}),
+			[
+				{
+					type: "Number",
+					value: -0.123,
+					end: 6,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 6,
+					start: 6,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-.123"}),
+			[
+				{
+					type: "Number",
+					value: -0.123,
+					end: 5,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-10e3"}),
+			[
+				{
+					type: "Number",
+					value: -10_000,
+					end: 5,
+					start: 0,
+					numberType: "integer",
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-3.4e-2"}),
+			[
+				{
+					type: "Number",
+					value: -0.034,
+					end: 7,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 7,
+					start: 7,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-->"}),
+			[
+				{
+					type: "CDC",
+					end: 3,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 3,
+					start: 3,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "-"}),
+			[
+				{
+					type: "Delim",
+					value: "-",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	".",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: ".123"}),
+			[
+				{
+					type: "Number",
+					value: 0.123,
+					end: 4,
+					start: 0,
+					numberType: "number",
+				},
+				{
+					type: "EOF",
+					end: 4,
+					start: 4,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"colon",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: ":"}),
+			[
+				{
+					type: "Colon",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"semi",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: ";"}),
+			[
+				{
+					type: "Semi",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"at-import",
+	(t) => {
+		function getResults(index: number, value: string) {
+			return [
+				{
+					type: "AtKeyword",
+					value,
+					end: index,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: index,
+					start: index,
+				},
+			];
+		}
+		t.looksLike(tokenizeCSS({input: "@import"}), getResults(7, "import"));
+		t.looksLike(tokenizeCSS({input: "@\\69mport"}), getResults(9, "import"));
+		t.looksLike(tokenizeCSS({input: "@\\0"}), getResults(3, "\ufffd"));
+	},
+);
+
+test(
+	"left-square-bracket",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "["}),
+			[
+				{
+					type: "LeftSquareBracket",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"\\",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "\\66oo"}),
+			[
+				{
+					type: "Ident",
+					value: "foo",
+					end: 5,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 5,
+					start: 5,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"digit",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "3"}),
+			[
+				{
+					type: "Number",
+					value: 3,
+					numberType: "integer",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"right-square-bracket",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "]"}),
+			[
+				{
+					type: "RightSquareBracket",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"left-curly-bracket",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "{"}),
+			[
+				{
+					type: "LeftCurlyBracket",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"right-curly-bracket",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "}"}),
+			[
+				{
+					type: "RightCurlyBracket",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"ident",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "foo"}),
+			[
+				{
+					type: "Ident",
+					value: "foo",
+					end: 3,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 3,
+					start: 3,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"url",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "url(foo)"}),
+			[
+				{
+					type: "URL",
+					value: "foo",
+					end: 8,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 8,
+					start: 8,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "url('foo')"}),
+			[
+				{
+					type: "Function",
+					value: "url",
+					end: 4,
+					start: 0,
+				},
+				{
+					type: "String",
+					value: "foo",
+					end: 9,
+					start: 4,
+				},
+				{
+					type: "RightParen",
+					end: 10,
+					start: 9,
+				},
+				{
+					type: "EOF",
+					end: 10,
+					start: 10,
+				},
+			],
+		);
+		t.looksLike(
+			tokenizeCSS({input: "url(   foo)"}),
+			[
+				{
+					type: "URL",
+					value: "foo",
+					end: 11,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 11,
+					start: 11,
+				},
+			],
+		);
+	},
+);
+
+test(
+	"arbitrary delim",
+	(t) => {
+		t.looksLike(
+			tokenizeCSS({input: "^"}),
+			[
+				{
+					type: "Delim",
+					value: "^",
+					end: 1,
+					start: 0,
+				},
+				{
+					type: "EOF",
+					end: 1,
+					start: 1,
+				},
+			],
+		);
+	},
+);

--- a/packages/@romejs/css-parser/parse.ts
+++ b/packages/@romejs/css-parser/parse.ts
@@ -1,0 +1,375 @@
+import {CSSParserOptions, Tokens} from "./types";
+import {ParserOptions, createParser, isDigit} from "@romejs/parser-core";
+import {DiagnosticCategory, descriptions} from "@romejs/diagnostics";
+import {Number0, ob1Add, ob1Get, ob1Get0, ob1Inc} from "@romejs/ob1";
+
+import {
+	consumeBadURL,
+	consumeChar,
+	consumeEscaped,
+	consumeName,
+	consumeNumber,
+	getChar,
+	getNewlineLength,
+	isIdentifierStart,
+	isName,
+	isNameStart,
+	isNewline,
+	isNumberStart,
+	isValidEscape,
+	isWhitespace,
+} from "./utils";
+
+export const createCSSParser = createParser((ParserCore) =>
+	class CSSParser extends ParserCore<Tokens> {
+		consumeDiagnosticCategory: DiagnosticCategory;
+		options: ParserOptions;
+
+		constructor(opts: CSSParserOptions) {
+			super(opts, "parse/css", {});
+
+			this.consumeDiagnosticCategory =
+				opts.consumeDiagnosticCategory || "parse/json";
+			this.ignoreWhitespaceTokens = false;
+			this.options = opts;
+		}
+
+		consumeIdentLikeToken(
+			index: Number0,
+			input: string,
+		): Tokens["Function"] | Tokens["Ident"] | Tokens["URL"] | Tokens["BadURL"] {
+			const [newIndex, name] = consumeName(index, input);
+			index = newIndex;
+			let value = name;
+
+			if (/url/gi.test(value) && getChar(index, input) === "(") {
+				index = ob1Inc(index);
+
+				while (
+					isWhitespace(getChar(index, input)) &&
+					isWhitespace(getChar(index, input, 1))
+				) {
+					index = ob1Inc(index);
+				}
+
+				if (getChar(index, input) === '"' || getChar(index, input) === "'") {
+					return this.finishValueToken("Function", value, index);
+				}
+
+				if (
+					isWhitespace(getChar(index, input)) &&
+					(getChar(index, input, 1) === '"' || getChar(index, input, 1) === "'")
+				) {
+					return this.finishValueToken("Function", value, ob1Add(index, 1));
+				}
+
+				return this.consumeURLToken(index, input);
+			}
+
+			if (getChar(index, input) === "(") {
+				return this.finishValueToken("Function", value, ob1Inc(index));
+			}
+
+			return this.finishValueToken("Ident", value, index);
+		}
+
+		consumeStringToken(
+			index: Number0,
+			input: string,
+			endChar?: string,
+		): Tokens["String"] | Tokens["BadString"] {
+			let value = "";
+
+			if (!endChar) {
+				[index, endChar] = consumeChar(index, input);
+			}
+
+			while (ob1Get(index) < input.length) {
+				const char = getChar(index, input);
+				const nextChar = getChar(index, input, 1);
+
+				if (char === endChar) {
+					return this.finishValueToken("String", value, ob1Inc(index));
+				} else if (this.isEOF(index)) {
+					this.createDiagnostic({
+						description: descriptions.CSS_PARSER.UNTERMINATED_STRING,
+					});
+					return this.finishValueToken("String", value, ob1Inc(index));
+				} else if (isNewline(char)) {
+					this.createDiagnostic({
+						description: descriptions.CSS_PARSER.UNTERMINATED_STRING,
+					});
+					return this.finishToken("BadString", index);
+				} else if (char === "\\") {
+					if (this.isEOF(ob1Inc(index))) {
+						continue;
+					}
+					if (isNewline(nextChar)) {
+						index = ob1Add(index, getNewlineLength(ob1Inc(index), input));
+					} else if (isValidEscape(char, nextChar)) {
+						const [newIndex, newValue] = consumeEscaped(index, input);
+						value += newValue;
+						index = newIndex;
+					}
+				} else {
+					value += char;
+					index = ob1Inc(index);
+				}
+			}
+
+			return this.finishValueToken("String", value, index);
+		}
+
+		consumeNumberToken(
+			index: Number0,
+			input: string,
+		): Tokens["Percentage"] | Tokens["Dimension"] | Tokens["Number"] {
+			const [newIndex, numberValue, numberType] = consumeNumber(index, input);
+			index = newIndex;
+
+			if (
+				isIdentifierStart(
+					getChar(index, input),
+					getChar(index, input, 1),
+					getChar(index, input, 2),
+				)
+			) {
+				const [endIndex, unit] = consumeName(index, input);
+				return this.finishComplexToken(
+					"Dimension",
+					{
+						numberType,
+						unit,
+						value: numberValue,
+					},
+					endIndex,
+				);
+			}
+
+			if (getChar(index, input) === "%") {
+				return this.finishValueToken("Percentage", numberValue, index);
+			}
+
+			return this.finishComplexToken(
+				"Number",
+				{
+					numberType,
+					value: numberValue,
+				},
+				index,
+			);
+		}
+
+		consumeURLToken(
+			index: Number0,
+			input: string,
+		): Tokens["URL"] | Tokens["BadURL"] {
+			let value = "";
+
+			while (isWhitespace(getChar(index, input))) {
+				index = ob1Inc(index);
+			}
+
+			while (ob1Get(index) < input.length) {
+				if (getChar(index, input) === ")") {
+					return this.finishValueToken("URL", value, ob1Inc(index));
+				}
+
+				if (this.isEOF(index)) {
+					this.createDiagnostic({
+						description: descriptions.CSS_PARSER.UNTERMINATED_URL,
+					});
+					return this.finishValueToken("URL", value);
+				}
+
+				if (isWhitespace(getChar(index, input))) {
+					while (isWhitespace(getChar(index, input))) {
+						index = ob1Inc(index);
+					}
+
+					if (getChar(index, input) === ")") {
+						return this.finishValueToken("URL", value, ob1Inc(index));
+					}
+
+					if (this.isEOF(index)) {
+						this.createDiagnostic({
+							description: descriptions.CSS_PARSER.UNTERMINATED_URL,
+						});
+						return this.finishValueToken("URL", value);
+					}
+
+					[index] = consumeBadURL(index, input);
+					return this.finishToken("BadURL", index);
+				}
+
+				if (
+					getChar(index, input) === '"' ||
+					getChar(index, input) === "'" ||
+					getChar(index, input) === "("
+				) {
+					this.createDiagnostic({
+						description: descriptions.CSS_PARSER.UNTERMINATED_URL,
+					});
+					[index] = consumeBadURL(index, input);
+					return this.finishToken("BadURL", index);
+				}
+
+				if (getChar(index, input) === "\\") {
+					if (isValidEscape(getChar(index, input), getChar(index, input))) {
+						const [newIndex, newValue] = consumeEscaped(index, input);
+						index = newIndex;
+						value += newValue;
+						continue;
+					}
+
+					this.createDiagnostic({
+						description: descriptions.CSS_PARSER.UNTERMINATED_URL,
+					});
+					[index] = consumeBadURL(index, input);
+					return this.finishToken("BadURL", index);
+				}
+
+				value += getChar(index, input);
+				index = ob1Inc(index);
+			}
+
+			throw new Error("Unrecoverable state due to bad URL");
+		}
+
+		tokenize(index: Number0, input: string) {
+			function getChar(offset = 0) {
+				return input[ob1Get0(index) + offset];
+			}
+
+			if (getChar() === "/" && getChar(1) === "*") {
+				index = ob1Add(index, 2);
+				while (getChar() !== "*" && getChar(1) !== "/") {
+					index = ob1Add(index, 1);
+				}
+			}
+
+			if (isWhitespace(getChar())) {
+				const endIndex = this.readInputFrom(index, isWhitespace)[1];
+				return this.finishToken("Whitespace", endIndex);
+			}
+
+			if (getChar() === '"') {
+				return this.consumeStringToken(index, input);
+			}
+
+			if (getChar() === "#") {
+				if (isName(getChar(1)) || isValidEscape(getChar(1), getChar(2))) {
+					const [endIndex, value] = consumeName(ob1Inc(index), input);
+					const isIdent = isIdentifierStart(getChar(1), getChar(2), getChar(3));
+					return this.finishComplexToken(
+						"Hash",
+						{
+							hashType: isIdent ? "id" : undefined,
+							value,
+						},
+						endIndex,
+					);
+				}
+				return this.finishValueToken("Delim", getChar());
+			}
+
+			if (getChar() === "'") {
+				return this.consumeStringToken(index, input);
+			}
+
+			if (getChar() === "(") {
+				return this.finishToken("LeftParen");
+			}
+
+			if (getChar() === ")") {
+				return this.finishToken("RightParen");
+			}
+
+			if (getChar() === "+") {
+				if (isNumberStart(getChar(), getChar(1), getChar(2))) {
+					return this.consumeNumberToken(index, input);
+				}
+				return this.finishValueToken("Delim", getChar());
+			}
+
+			if (getChar() === ",") {
+				return this.finishToken("Comma");
+			}
+
+			if (getChar() === "-") {
+				if (isNumberStart(getChar(), getChar(1), getChar(2))) {
+					return this.consumeNumberToken(index, input);
+				}
+
+				if (getChar(1) === "-" && getChar(2) === ">") {
+					return this.finishToken("CDC", ob1Add(index, 3));
+				}
+
+				if (isIdentifierStart(getChar(), getChar(1), getChar(2))) {
+					return this.consumeIdentLikeToken(index, input);
+				}
+
+				return this.finishValueToken("Delim", getChar());
+			}
+
+			if (getChar() === ".") {
+				if (isNumberStart(getChar(), getChar(1), getChar(2))) {
+					return this.consumeNumberToken(index, input);
+				}
+				return this.finishValueToken("Delim", getChar());
+			}
+
+			if (getChar() === ":") {
+				return this.finishToken("Colon");
+			}
+
+			if (getChar() === ";") {
+				return this.finishToken("Semi");
+			}
+
+			if (getChar() === "@") {
+				if (isIdentifierStart(getChar(1), getChar(2), getChar(3))) {
+					const [endIndex, value] = consumeName(ob1Inc(index), input);
+					return this.finishValueToken("AtKeyword", value, endIndex);
+				}
+				return this.finishValueToken("Delim", getChar());
+			}
+
+			if (getChar() === "[") {
+				return this.finishToken("LeftSquareBracket");
+			}
+
+			if (getChar() === "\\") {
+				if (isValidEscape(getChar(), getChar(1))) {
+					return this.consumeIdentLikeToken(index, input);
+				}
+				this.createDiagnostic({
+					description: descriptions.CSS_PARSER.INVALID_ESCAPE,
+				});
+				return this.finishValueToken("Delim", getChar());
+			}
+
+			if (getChar() === "]") {
+				return this.finishToken("RightSquareBracket");
+			}
+
+			if (getChar() === "{") {
+				return this.finishToken("LeftCurlyBracket");
+			}
+
+			if (getChar() === "}") {
+				return this.finishToken("RightCurlyBracket");
+			}
+
+			if (isDigit(getChar())) {
+				return this.consumeNumberToken(index, input);
+			}
+
+			if (isNameStart(getChar())) {
+				return this.consumeIdentLikeToken(index, input);
+			}
+
+			return this.finishValueToken("Delim", getChar());
+		}
+	}
+);

--- a/packages/@romejs/css-parser/types.ts
+++ b/packages/@romejs/css-parser/types.ts
@@ -1,0 +1,57 @@
+import {
+	BaseTokens,
+	ComplexToken,
+	ParserOptions,
+	SimpleToken,
+	ValueToken,
+} from "@romejs/parser-core";
+import {DiagnosticCategory} from "@romejs/diagnostics";
+
+export interface CSSParserOptions extends Omit<
+	ParserOptions,
+	"ignoreWhitespaceTokens"
+> {
+	consumeDiagnosticCategory?: DiagnosticCategory;
+}
+
+export interface DimensionData {
+	numberType: string;
+	unit: string;
+	value: number;
+}
+
+export interface HashData {
+	hashType?: string;
+	value: string;
+}
+
+export interface NumberData {
+	numberType: string;
+	value: number;
+}
+
+export type Tokens = BaseTokens & {
+	AtKeyword: ValueToken<"AtKeyword", string>;
+	BadString: SimpleToken<"BadString">;
+	BadURL: SimpleToken<"BadURL">;
+	CDC: SimpleToken<"CDC">;
+	Colon: SimpleToken<"Colon">;
+	Comma: SimpleToken<"Comma">;
+	Delim: ValueToken<"Delim", string>;
+	Dimension: ComplexToken<"Dimension", DimensionData>;
+	Function: ValueToken<"Function", string>;
+	Hash: ComplexToken<"Hash", HashData>;
+	Ident: ValueToken<"Ident", string>;
+	LeftCurlyBracket: SimpleToken<"LeftCurlyBracket">;
+	LeftParen: SimpleToken<"LeftParen">;
+	LeftSquareBracket: SimpleToken<"LeftSquareBracket">;
+	Number: ComplexToken<"Number", NumberData>;
+	Percentage: ValueToken<"Percentage", number>;
+	RightCurlyBracket: SimpleToken<"RightCurlyBracket">;
+	RightParen: SimpleToken<"RightParen">;
+	RightSquareBracket: SimpleToken<"RightSquareBracket">;
+	Semi: SimpleToken<"Semi">;
+	String: ValueToken<"String", string>;
+	URL: ValueToken<"URL", string>;
+	Whitespace: SimpleToken<"Whitespace">;
+};

--- a/packages/@romejs/css-parser/utils.ts
+++ b/packages/@romejs/css-parser/utils.ts
@@ -1,0 +1,268 @@
+import {Number0, ob1Add, ob1Get, ob1Inc} from "@romejs/ob1";
+import {isAlpha, isDigit, isHexDigit} from "@romejs/parser-core";
+
+export const Symbols = {
+	CarriageReturn: "\r",
+	Control: 0x80,
+	FormFeed: "\f",
+	LineFeed: "\n",
+	MaxValue: 0x10ffff,
+	Replace: "\ufffd",
+	Space: " ",
+	SurrogateMax: 0xdfff,
+	SurrogateMin: 0xd800,
+	Tab: "\t",
+};
+
+export function consumeBadURL(index: Number0, input: string): [Number0] {
+	while (ob1Get(index) < input.length) {
+		if (getChar(index, input) === ")") {
+			return [ob1Inc(index)];
+		}
+
+		if (isValidEscape(getChar(index, input), getChar(index, input, 1))) {
+			[index] = consumeEscaped(index, input);
+		} else {
+			index = ob1Inc(index);
+		}
+	}
+	return [index];
+}
+
+export function consumeChar(index: Number0, input: string): [Number0, string] {
+	return [ob1Inc(index), getChar(index, input)];
+}
+
+export function consumeEscaped(index: Number0, input: string): [Number0, string] {
+	let value = "";
+	index = ob1Add(index, 2);
+	const lastChar = getChar(index, input, -1);
+
+	if (isHexDigit(lastChar)) {
+		const maxOffset = Math.min(input.length, ob1Get(index) + 5);
+		let hexString = lastChar;
+		let utf8Value = "";
+
+		while (ob1Get(index) < maxOffset) {
+			if (!isHexDigit(getChar(index, input))) {
+				break;
+			}
+			hexString += getChar(index, input);
+			index = ob1Inc(index);
+		}
+		const hexNumber = parseInt(hexString, 16);
+		if (
+			hexNumber === 0 ||
+			hexNumber > Symbols.MaxValue ||
+			(hexNumber >= Symbols.SurrogateMin && hexNumber <= Symbols.SurrogateMax)
+		) {
+			utf8Value = Symbols.Replace;
+		} else {
+			utf8Value = hexToUtf8(hexString);
+		}
+		value += utf8Value;
+
+		if (isWhitespace(input[ob1Get(index)])) {
+			index = ob1Add(index, getNewlineLength(index, input));
+		}
+	}
+
+	return [index, value];
+}
+
+export function consumeName(index: Number0, input: string): [Number0, string] {
+	let value = "";
+
+	while (ob1Get(index) < input.length) {
+		const char1 = getChar(index, input);
+		const char2 = getChar(index, input, 1);
+
+		if (isName(char1)) {
+			value += char1;
+			index = ob1Inc(index);
+			continue;
+		}
+
+		if (isValidEscape(char1, char2)) {
+			const [newIndex, newValue] = consumeEscaped(index, input);
+			value += newValue;
+			index = newIndex;
+			continue;
+		}
+
+		break;
+	}
+
+	return [index, value];
+}
+
+export function consumeNumber(
+	index: Number0,
+	input: string,
+): [Number0, number, string] {
+	const char = getChar(index, input);
+	let value = "";
+	let type = "integer";
+
+	if (char === "+" || char === "-") {
+		value += char;
+		index = ob1Inc(index);
+	}
+
+	while (isDigit(getChar(index, input))) {
+		value += getChar(index, input);
+		index = ob1Inc(index);
+	}
+
+	if (getChar(index, input) === "." && isDigit(getChar(index, input, 1))) {
+		value += getChar(index, input);
+		index = ob1Inc(index);
+
+		value += getChar(index, input);
+		index = ob1Inc(index);
+
+		type = "number";
+
+		while (isDigit(getChar(index, input))) {
+			value += getChar(index, input);
+			index = ob1Inc(index);
+		}
+	}
+
+	const char1 = getChar(index, input);
+	const char2 = getChar(index, input, 1);
+	const char3 = getChar(index, input, 2);
+
+	if (char1 === "E" || char1 === "e") {
+		if (isDigit(char2)) {
+			value += getChar(index, input);
+			index = ob1Inc(index);
+
+			value += getChar(index, input);
+			index = ob1Inc(index);
+		} else if ((char2 === "-" || char2 === "+") && isDigit(char3)) {
+			value += getChar(index, input);
+			index = ob1Inc(index);
+
+			value += getChar(index, input);
+			index = ob1Inc(index);
+
+			value += getChar(index, input);
+			index = ob1Inc(index);
+
+			while (isDigit(getChar(index, input))) {
+				value += getChar(index, input);
+				index = ob1Inc(index);
+			}
+		}
+	}
+
+	return [index, parseFloat(value), type];
+}
+
+export function getChar(index: Number0, input: string, offset = 0): string {
+	const targetIndex = ob1Get(index) + offset;
+	return input[targetIndex];
+}
+
+export function getCodePoint(char: string): number {
+	if (!char) {
+		return -1;
+	}
+
+	if (char.length === 1) {
+		const point = char.codePointAt(0);
+		if (point !== undefined) {
+			return point;
+		}
+	}
+
+	throw new Error("Input was not 1 character long");
+}
+
+export function getNewlineLength(index: Number0, input: string): number {
+	if (
+		getChar(index, input) === Symbols.CarriageReturn &&
+		getChar(index, input, 1) === Symbols.LineFeed
+	) {
+		return 2;
+	}
+
+	return 1;
+}
+
+export function hexToUtf8(hex: string): string {
+	const match = hex.match(/.{1,2}/g);
+	return match ? decodeURIComponent(`%${match.join("%")}`) : Symbols.Replace;
+}
+
+export function isIdentifierStart(
+	char1: string,
+	char2: string,
+	char3: string,
+): boolean {
+	if (char1 === "-") {
+		return isNameStart(char2) || char2 === "-" || isValidEscape(char2, char3);
+	}
+
+	if (isNameStart(char1)) {
+		return true;
+	}
+
+	if (char1 === "\\") {
+		return isValidEscape(char1, char2);
+	}
+
+	return false;
+}
+
+export function isName(char: string): boolean {
+	return isNameStart(char) || isDigit(char) || char === "-";
+}
+
+export function isNameStart(char: string): boolean {
+	return isAlpha(char) || isNonAscii(char) || char === "_";
+}
+
+export function isNewline(char: string): boolean {
+	return (
+		char === Symbols.LineFeed ||
+		char === Symbols.CarriageReturn ||
+		char === Symbols.FormFeed
+	);
+}
+
+export function isNonAscii(char: string): boolean {
+	return getCodePoint(char) >= Symbols.Control;
+}
+
+export function isNumberStart(
+	char1: string,
+	char2: string,
+	char3: string,
+): boolean {
+	if (char1 === "+" || char1 === "-") {
+		if (isDigit(char2)) {
+			return true;
+		}
+		return char2 === "." && isDigit(char3);
+	}
+
+	if (char1 === ".") {
+		return isDigit(char2);
+	}
+
+	return isDigit(char1);
+}
+
+export function isValidEscape(char1: string, char2?: string): boolean {
+	if (char1 !== "\\" || !char2 || isNewline(char2)) {
+		return false;
+	}
+
+	return true;
+}
+
+export function isWhitespace(char: string): boolean {
+	return isNewline(char) || char === Symbols.Space || char === Symbols.Tab;
+}

--- a/packages/@romejs/diagnostics/categories.ts
+++ b/packages/@romejs/diagnostics/categories.ts
@@ -27,6 +27,7 @@ export type DiagnosticCategory =
 	| "lint/pendingFixes"
 	| "lsp/parse"
 	| "parse/html"
+	| "parse/css"
 	| "parse/js"
 	| "parse/json"
 	| "parse/manifest"

--- a/packages/@romejs/diagnostics/descriptions/cssParser.ts
+++ b/packages/@romejs/diagnostics/descriptions/cssParser.ts
@@ -1,0 +1,7 @@
+import {createDiagnosticsCategory} from "./index";
+
+export const cssParser = createDiagnosticsCategory({
+	INVALID_ESCAPE: "Invalid escape sequence",
+	UNTERMINATED_STRING: "Unterminated string",
+	UNTERMINATED_URL: "Unterminated URL",
+});

--- a/packages/@romejs/diagnostics/descriptions/index.ts
+++ b/packages/@romejs/diagnostics/descriptions/index.ts
@@ -30,6 +30,7 @@ import {bundler} from "./bundler";
 import {resolver} from "./resolver";
 import {spdx} from "./spdx";
 import {jsParser} from "./jsParser";
+import {cssParser} from "./cssParser";
 import {typeCheck} from "./typeCheck";
 import {consume} from "./consume";
 import {manifest} from "./manifest";
@@ -171,6 +172,7 @@ export const descriptions = {
 	RESOLVER: resolver,
 	SPDX: spdx,
 	JS_PARSER: jsParser,
+	CSS_PARSER: cssParser,
 	TYPE_CHECK: typeCheck,
 	CONSUME: consume,
 	MANIFEST: manifest,


### PR DESCRIPTION
This pull request adds a new `css-parser` package that exposes a tolerant CSS tokenizer for the complete [CSS3 specification](https://www.w3.org/TR/css-syntax-3/#tokenization).

**TODO:**

1. Implement parser.
1. Add exhaustive tests.
1. Further verify spec compliancy.