### PR TITLE
Transfer buffers in WorkerManager replaceOwnWorker

### DIFF
--- a/packages/@romejs/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romejs/core/common/bridges/WorkerBridge.ts
@@ -242,7 +242,7 @@ export default class WorkerBridge extends Bridge {
 	getFileBuffers = this.createEvent<
 		void,
 		Array<{
-			file: string;
+			filename: string;
 			content: string;
 		}>
 	>({

--- a/packages/@romejs/core/common/bridges/WorkerBridge.ts
+++ b/packages/@romejs/core/common/bridges/WorkerBridge.ts
@@ -239,6 +239,17 @@ export default class WorkerBridge extends Bridge {
 		AnyRoot
 	>({name: "parse", direction: "server->client"});
 
+	getFileBuffers = this.createEvent<
+		void,
+		Array<{
+			file: string;
+			content: string;
+		}>
+	>({
+		name: "getFileBuffers",
+		direction: "server->client",
+	});
+
 	updateBuffer = this.createEvent<
 		{
 			file: JSONFileReference;

--- a/packages/@romejs/core/server/WorkerManager.ts
+++ b/packages/@romejs/core/server/WorkerManager.ts
@@ -173,10 +173,10 @@ export default class WorkerManager {
 			// Transfer buffers to the new worker
 			const buffers = await serverWorker.bridge.getFileBuffers.call();
 
-			for (const {file, content} of buffers) {
+			for (const {filename, content} of buffers) {
 				await newWorker.bridge.updateBuffer.call({
 					file: this.server.projectManager.getTransportFileReference(
-						createAbsoluteFilePath(file),
+						createAbsoluteFilePath(filename),
 					),
 					content,
 				});

--- a/packages/@romejs/core/worker/Worker.ts
+++ b/packages/@romejs/core/worker/Worker.ts
@@ -236,6 +236,10 @@ export default class Worker {
 		bridge.clearBuffer.subscribe((payload) => {
 			return this.clearBuffer(convertTransportFileReference(payload.file));
 		});
+
+		bridge.getFileBuffers.subscribe(() => {
+			return this.getFileBuffers();
+		});
 	}
 
 	clearBuffer({real}: FileReference) {
@@ -248,6 +252,13 @@ export default class Worker {
 		this.logger.info(`Updated ${ref.real.toMarkup()} buffer`);
 		this.buffers.set(ref.real, content);
 		this.evict(ref.real);
+	}
+
+	getFileBuffers() {
+		return Array.from(
+			this.buffers,
+			([path, content]) => ({file: path.join(), content}),
+		);
 	}
 
 	async getTypeCheckProvider(

--- a/packages/@romejs/core/worker/Worker.ts
+++ b/packages/@romejs/core/worker/Worker.ts
@@ -257,7 +257,7 @@ export default class Worker {
 	getFileBuffers() {
 		return Array.from(
 			this.buffers,
-			([path, content]) => ({file: path.join(), content}),
+			([path, content]) => ({filename: path.join(), content}),
 		);
 	}
 


### PR DESCRIPTION
This transfers buffers to the newly spawned worker when it replaces the internal server worker.