### PR TITLE
[WIP] Markdown ast nodes

### DIFF
--- a/packages/@romejs/ast/index.ts
+++ b/packages/@romejs/ast/index.ts
@@ -208,6 +208,21 @@ export * from "./js/jsx/JSXSpreadAttribute";
 export * from "./js/jsx/JSXSpreadChild";
 export * from "./js/jsx/JSXText";
 export * from "./js/expressions/JSYieldExpression";
+export * from "./markdown/inline/MarkdownAutomaticLinkInline";
+export * from "./markdown/inline/MarkdownBoldInline";
+export * from "./markdown/blocks/MarkdownCodeBlock";
+export * from "./markdown/inline/MarkdownCodeInline";
+export * from "./markdown/inline/MarkdownDefinitionInline";
+export * from "./markdown/blocks/MarkdownDividerBlock";
+export * from "./markdown/inline/MarkdownEmphasisInline";
+export * from "./markdown/blocks/MarkdownHeadingBlock";
+export * from "./markdown/inline/MarkdownImageInline";
+export * from "./markdown/inline/MarkdownLinkInline";
+export * from "./markdown/blocks/MarkdownListBlock";
+export * from "./markdown/core/MarkdownParagraph";
+export * from "./markdown/blocks/MarkdownQuoteBlock";
+export * from "./markdown/core/MarkDownRoot";
+export * from "./markdown/core/MarkdownText";
 export * from "./common/core/MockParent";
 export * from "./js/typescript/TSAnyKeywordTypeAnnotation";
 export * from "./js/typescript/TSArrayType";
@@ -473,6 +488,21 @@ export type AnyNode =
 	| n.JSXSpreadChild
 	| n.JSXText
 	| n.JSYieldExpression
+	| n.MarkdownAutomaticLinkInline
+	| n.MarkdownBoldInline
+	| n.MarkdownCodeBlock
+	| n.MarkdownCodeInline
+	| n.MarkdownDefinitionInline
+	| n.MarkdownDividerBlock
+	| n.MarkdownEmphasisInline
+	| n.MarkdownHeadingBlock
+	| n.MarkdownImageInline
+	| n.MarkdownLinkInline
+	| n.MarkdownListBlock
+	| n.MarkdownParagraph
+	| n.MarkdownQuoteBlock
+	| n.MarkDownRoot
+	| n.MarkdownText
 	| n.MockParent
 	| n.TSAnyKeywordTypeAnnotation
 	| n.TSArrayType

--- a/packages/@romejs/ast/index.ts
+++ b/packages/@romejs/ast/index.ts
@@ -219,6 +219,7 @@ export * from "./markdown/blocks/MarkdownHeadingBlock";
 export * from "./markdown/inline/MarkdownImageInline";
 export * from "./markdown/inline/MarkdownLinkInline";
 export * from "./markdown/blocks/MarkdownListBlock";
+export * from "./markdown/core/MarkdownListItem";
 export * from "./markdown/core/MarkdownParagraph";
 export * from "./markdown/blocks/MarkdownQuoteBlock";
 export * from "./markdown/core/MarkDownRoot";
@@ -499,6 +500,7 @@ export type AnyNode =
 	| n.MarkdownImageInline
 	| n.MarkdownLinkInline
 	| n.MarkdownListBlock
+	| n.MarkdownListItem
 	| n.MarkdownParagraph
 	| n.MarkdownQuoteBlock
 	| n.MarkDownRoot

--- a/packages/@romejs/ast/markdown/blocks/MarkdownCodeBlock.ts
+++ b/packages/@romejs/ast/markdown/blocks/MarkdownCodeBlock.ts
@@ -1,0 +1,14 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+export type MarkdownCodeBlock = NodeBaseWithComments & {
+	type: "MarkdownCodeBlock";
+};
+
+export const markdownCodeBlock = createBuilder<MarkdownCodeBlock>(
+	"MarkdownCodeBlock",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/blocks/MarkdownDividerBlock.ts
+++ b/packages/@romejs/ast/markdown/blocks/MarkdownDividerBlock.ts
@@ -1,0 +1,14 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+export type MarkdownDividerBlock = NodeBaseWithComments & {
+	type: "MarkdownDividerBlock";
+};
+
+export const markdownDividerBlock = createBuilder<MarkdownDividerBlock>(
+	"MarkdownDividerBlock",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/blocks/MarkdownHeadingBlock.ts
+++ b/packages/@romejs/ast/markdown/blocks/MarkdownHeadingBlock.ts
@@ -1,0 +1,20 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+// # Something
+// #### Some other thing
+export type MarkdownHeadingBlock = NodeBaseWithComments & {
+	type: "MarkdownHeadingBlock";
+	level: number;
+	value: string;
+};
+
+export const markdownHeadingBlock = createBuilder<MarkdownHeadingBlock>(
+	"MarkdownHeadingBlock",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			level: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/blocks/MarkdownListBlock.ts
+++ b/packages/@romejs/ast/markdown/blocks/MarkdownListBlock.ts
@@ -1,0 +1,19 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+import {MarkdownListChildren} from "@romejs/ast/markdown/types";
+
+export type MarkdownListBlock = NodeBaseWithComments & {
+	type: "MarkdownListBlock";
+	kind: "dot-list" | "numeric-list";
+	children: Array<MarkdownListChildren>;
+};
+
+export const markdownListBlock = createBuilder<MarkdownListBlock>(
+	"MarkdownListBlock",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			children: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/blocks/MarkdownListBlock.ts
+++ b/packages/@romejs/ast/markdown/blocks/MarkdownListBlock.ts
@@ -1,11 +1,10 @@
-import {NodeBaseWithComments} from "@romejs/ast";
+import {MarkdownListItem, NodeBaseWithComments} from "@romejs/ast";
 import {createBuilder} from "../../utils";
-import {MarkdownListChildren} from "@romejs/ast/markdown/types";
 
 export type MarkdownListBlock = NodeBaseWithComments & {
 	type: "MarkdownListBlock";
 	kind: "dot-list" | "numeric-list";
-	children: Array<MarkdownListChildren>;
+	children: Array<MarkdownListItem>;
 };
 
 export const markdownListBlock = createBuilder<MarkdownListBlock>(

--- a/packages/@romejs/ast/markdown/blocks/MarkdownQuoteBlock.ts
+++ b/packages/@romejs/ast/markdown/blocks/MarkdownQuoteBlock.ts
@@ -1,0 +1,19 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+import {MarkdownQuoteChildren} from "@romejs/ast/markdown/types";
+
+// > this quote
+export type MarkdownQuoteBlock = NodeBaseWithComments & {
+	type: "MarkdownQuoteBlock";
+	children: Array<MarkdownQuoteChildren>;
+};
+
+export const markdownQuoteBlock = createBuilder<MarkdownQuoteBlock>(
+	"MarkdownQuoteBlock",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			children: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/core/MarkDownRoot.ts
+++ b/packages/@romejs/ast/markdown/core/MarkDownRoot.ts
@@ -1,0 +1,14 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+export type MarkDownRoot = NodeBaseWithComments & {
+	type: "MarkDownRoot";
+};
+
+export const markDownRoot = createBuilder<MarkDownRoot>(
+	"MarkDownRoot",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/core/MarkdownListItem.ts
+++ b/packages/@romejs/ast/markdown/core/MarkdownListItem.ts
@@ -1,0 +1,19 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+import {MarkdownListChildren} from "@romejs/ast/markdown/types";
+
+export type MarkdownListItem = NodeBaseWithComments & {
+	type: "MarkdownListItem";
+	checked: boolean | null;
+	children: Array<MarkdownListChildren>;
+};
+
+export const markdownListItem = createBuilder<MarkdownListItem>(
+	"MarkdownListItem",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			children: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/core/MarkdownParagraph.ts
+++ b/packages/@romejs/ast/markdown/core/MarkdownParagraph.ts
@@ -1,0 +1,17 @@
+import {MarkdownText, NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+export type MarkdownParagraph = NodeBaseWithComments & {
+	type: "MarkdownParagraph";
+	value: Array<MarkdownText>;
+};
+
+export const markdownParagraph = createBuilder<MarkdownParagraph>(
+	"MarkdownParagraph",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			value: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/core/MarkdownText.ts
+++ b/packages/@romejs/ast/markdown/core/MarkdownText.ts
@@ -1,0 +1,17 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+export type MarkdownText = NodeBaseWithComments & {
+	type: "MarkdownText";
+	value: string;
+};
+
+export const markdownText = createBuilder<MarkdownText>(
+	"MarkdownText",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			value: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownAutomaticLinkInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownAutomaticLinkInline.ts
@@ -1,0 +1,16 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+// <something.com/>
+// TODO here we have to obscure the email
+export type MarkdownAutomaticLinkInline = NodeBaseWithComments & {
+	type: "MarkdownAutomaticLinkInline";
+};
+
+export const markdownAutomaticLinkInline = createBuilder<MarkdownAutomaticLinkInline>(
+	"MarkdownAutomaticLinkInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownBoldInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownBoldInline.ts
@@ -1,0 +1,16 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+// **something**
+export type MarkdownBoldInline = NodeBaseWithComments & {
+	type: "MarkdownBoldInline";
+	value: string;
+};
+
+export const markdownBoldInline = createBuilder<MarkdownBoldInline>(
+	"MarkdownBoldInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownCodeInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownCodeInline.ts
@@ -1,0 +1,15 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+export type MarkdownCodeInline = NodeBaseWithComments & {
+	type: "MarkdownCodeInline";
+	value: string;
+};
+
+export const markdownCodeInline = createBuilder<MarkdownCodeInline>(
+	"MarkdownCodeInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownDefinitionInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownDefinitionInline.ts
@@ -1,0 +1,24 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+// [link]: www.example.com "Title"
+export type MarkdownDefinitionInline = NodeBaseWithComments & {
+	type: "MarkdownDefinitionInline";
+	value: string;
+	url: string;
+	title: string;
+	// TODO make sure identifier is unique somewhere/somehow
+	identifier: string;
+};
+
+export const markdownDefinitionInline = createBuilder<MarkdownDefinitionInline>(
+	"MarkdownDefinitionInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			url: true,
+			title: true,
+			identifier: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownEmphasisInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownEmphasisInline.ts
@@ -1,0 +1,16 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+
+// *emphasis*
+export type MarkdownEmphasisInline = NodeBaseWithComments & {
+	type: "MarkdownEmphasisInline";
+	value: string;
+};
+
+export const markdownEmphasisInline = createBuilder<MarkdownEmphasisInline>(
+	"MarkdownEmphasisInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownImageInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownImageInline.ts
@@ -1,0 +1,21 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+import {MarkdownReference} from "@romejs/ast/markdown/types";
+
+// ![Atl text](//url)
+// ![Atl text] [1]
+export type MarkdownImageInline = NodeBaseWithComments & {
+	type: "MarkdownImageInline";
+	url: MarkdownReference;
+	altText: string;
+};
+
+export const markdownImageInline = createBuilder<MarkdownImageInline>(
+	"MarkdownImageInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			url: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/inline/MarkdownLinkInline.ts
+++ b/packages/@romejs/ast/markdown/inline/MarkdownLinkInline.ts
@@ -1,0 +1,21 @@
+import {NodeBaseWithComments} from "@romejs/ast";
+import {createBuilder} from "../../utils";
+import {MarkdownReference} from "@romejs/ast/markdown/types";
+
+// [link](www.example.com)
+export type MarkdownLinkInline = NodeBaseWithComments & {
+	type: "MarkdownLinkInline";
+	value: string;
+	url: MarkdownReference;
+	title?: string;
+};
+
+export const markdownLinkInline = createBuilder<MarkdownLinkInline>(
+	"MarkdownLinkInline",
+	{
+		bindingKeys: {},
+		visitorKeys: {
+			url: true,
+		},
+	},
+);

--- a/packages/@romejs/ast/markdown/types.ts
+++ b/packages/@romejs/ast/markdown/types.ts
@@ -1,0 +1,10 @@
+import * as n from "@romejs/ast";
+
+export type MarkdownListChildren = n.MarkdownQuoteBlock | n.MarkdownParagraph;
+
+export type MarkdownQuoteChildren =
+	| n.MarkdownQuoteBlock
+	| n.MarkdownParagraph
+	| n.MarkdownHeadingBlock;
+
+export type MarkdownReference = n.MarkdownParagraph | n.MarkdownDefinitionInline;

--- a/packages/@romejs/formatter/builders/index.ts
+++ b/packages/@romejs/formatter/builders/index.ts
@@ -647,6 +647,9 @@ builders.set("MarkdownLinkInline", MarkdownLinkInline);
 import MarkdownListBlock from "./markdown/blocks/MarkdownListBlock";
 builders.set("MarkdownListBlock", MarkdownListBlock);
 
+import MarkdownListItem from "./markdown/core/MarkdownListItem";
+builders.set("MarkdownListItem", MarkdownListItem);
+
 import MarkdownParagraph from "./markdown/core/MarkdownParagraph";
 builders.set("MarkdownParagraph", MarkdownParagraph);
 

--- a/packages/@romejs/formatter/builders/index.ts
+++ b/packages/@romejs/formatter/builders/index.ts
@@ -614,6 +614,51 @@ builders.set("JSXText", JSXText);
 import JSYieldExpression from "./js/expressions/JSYieldExpression";
 builders.set("JSYieldExpression", JSYieldExpression);
 
+import MarkdownAutomaticLinkInline from "./markdown/inline/MarkdownAutomaticLinkInline";
+builders.set("MarkdownAutomaticLinkInline", MarkdownAutomaticLinkInline);
+
+import MarkdownBoldInline from "./markdown/inline/MarkdownBoldInline";
+builders.set("MarkdownBoldInline", MarkdownBoldInline);
+
+import MarkdownCodeBlock from "./markdown/blocks/MarkdownCodeBlock";
+builders.set("MarkdownCodeBlock", MarkdownCodeBlock);
+
+import MarkdownCodeInline from "./markdown/inline/MarkdownCodeInline";
+builders.set("MarkdownCodeInline", MarkdownCodeInline);
+
+import MarkdownDefinitionInline from "./markdown/inline/MarkdownDefinitionInline";
+builders.set("MarkdownDefinitionInline", MarkdownDefinitionInline);
+
+import MarkdownDividerBlock from "./markdown/blocks/MarkdownDividerBlock";
+builders.set("MarkdownDividerBlock", MarkdownDividerBlock);
+
+import MarkdownEmphasisInline from "./markdown/inline/MarkdownEmphasisInline";
+builders.set("MarkdownEmphasisInline", MarkdownEmphasisInline);
+
+import MarkdownHeadingBlock from "./markdown/blocks/MarkdownHeadingBlock";
+builders.set("MarkdownHeadingBlock", MarkdownHeadingBlock);
+
+import MarkdownImageInline from "./markdown/inline/MarkdownImageInline";
+builders.set("MarkdownImageInline", MarkdownImageInline);
+
+import MarkdownLinkInline from "./markdown/inline/MarkdownLinkInline";
+builders.set("MarkdownLinkInline", MarkdownLinkInline);
+
+import MarkdownListBlock from "./markdown/blocks/MarkdownListBlock";
+builders.set("MarkdownListBlock", MarkdownListBlock);
+
+import MarkdownParagraph from "./markdown/core/MarkdownParagraph";
+builders.set("MarkdownParagraph", MarkdownParagraph);
+
+import MarkdownQuoteBlock from "./markdown/blocks/MarkdownQuoteBlock";
+builders.set("MarkdownQuoteBlock", MarkdownQuoteBlock);
+
+import MarkDownRoot from "./markdown/core/MarkDownRoot";
+builders.set("MarkDownRoot", MarkDownRoot);
+
+import MarkdownText from "./markdown/core/MarkdownText";
+builders.set("MarkdownText", MarkdownText);
+
 import MockParent from "./common/core/MockParent";
 builders.set("MockParent", MockParent);
 

--- a/packages/@romejs/formatter/builders/markdown/blocks/MarkdownCodeBlock.ts
+++ b/packages/@romejs/formatter/builders/markdown/blocks/MarkdownCodeBlock.ts
@@ -1,0 +1,9 @@
+import {MarkdownCodeBlock} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownCodeBlock(
+	builder: Builder,
+	node: MarkdownCodeBlock,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/blocks/MarkdownDividerBlock.ts
+++ b/packages/@romejs/formatter/builders/markdown/blocks/MarkdownDividerBlock.ts
@@ -1,0 +1,9 @@
+import {MarkdownDividerBlock} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownDividerBlock(
+	builder: Builder,
+	node: MarkdownDividerBlock,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/blocks/MarkdownHeadingBlock.ts
+++ b/packages/@romejs/formatter/builders/markdown/blocks/MarkdownHeadingBlock.ts
@@ -1,0 +1,9 @@
+import {MarkdownHeadingBlock} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownHeadingBlock(
+	builder: Builder,
+	node: MarkdownHeadingBlock,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/blocks/MarkdownListBlock.ts
+++ b/packages/@romejs/formatter/builders/markdown/blocks/MarkdownListBlock.ts
@@ -1,0 +1,9 @@
+import {MarkdownListBlock} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownListBlock(
+	builder: Builder,
+	node: MarkdownListBlock,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/blocks/MarkdownQuoteBlock.ts
+++ b/packages/@romejs/formatter/builders/markdown/blocks/MarkdownQuoteBlock.ts
@@ -1,0 +1,9 @@
+import {MarkdownQuoteBlock} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownQuoteBlock(
+	builder: Builder,
+	node: MarkdownQuoteBlock,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/core/MarkDownRoot.ts
+++ b/packages/@romejs/formatter/builders/markdown/core/MarkDownRoot.ts
@@ -1,0 +1,9 @@
+import {MarkDownRoot} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkDownRoot(
+	builder: Builder,
+	node: MarkDownRoot,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/core/MarkdownListItem.ts
+++ b/packages/@romejs/formatter/builders/markdown/core/MarkdownListItem.ts
@@ -1,0 +1,9 @@
+import {MarkdownListItem} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownListItem(
+	builder: Builder,
+	node: MarkdownListItem,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/core/MarkdownParagraph.ts
+++ b/packages/@romejs/formatter/builders/markdown/core/MarkdownParagraph.ts
@@ -1,0 +1,9 @@
+import {MarkdownParagraph} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownParagraph(
+	builder: Builder,
+	node: MarkdownParagraph,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/core/MarkdownText.ts
+++ b/packages/@romejs/formatter/builders/markdown/core/MarkdownText.ts
@@ -1,0 +1,9 @@
+import {MarkdownText} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownText(
+	builder: Builder,
+	node: MarkdownText,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownAutomaticLinkInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownAutomaticLinkInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownAutomaticLinkInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownAutomaticLinkInline(
+	builder: Builder,
+	node: MarkdownAutomaticLinkInline,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownBoldInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownBoldInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownBoldInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownBoldInline(
+	builder: Builder,
+	node: MarkdownBoldInline,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownCodeInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownCodeInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownCodeInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownCodeInline(
+	builder: Builder,
+	node: MarkdownCodeInline,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownDefinitionInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownDefinitionInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownDefinitionInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownDefinitionInline(
+	builder: Builder,
+	node: MarkdownDefinitionInline,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownEmphasisInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownEmphasisInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownEmphasisInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownEmphasisInline(
+	builder: Builder,
+	node: MarkdownEmphasisInline,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownImageInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownImageInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownImageInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownImageInline(
+	builder: Builder,
+	node: MarkdownImageInline,
+): Token {
+	throw new Error("unimplemented");
+}

--- a/packages/@romejs/formatter/builders/markdown/inline/MarkdownLinkInline.ts
+++ b/packages/@romejs/formatter/builders/markdown/inline/MarkdownLinkInline.ts
@@ -1,0 +1,9 @@
+import {MarkdownLinkInline} from "@romejs/ast";
+import {Builder, Token} from "@romejs/formatter";
+
+export default function MarkdownLinkInline(
+	builder: Builder,
+	node: MarkdownLinkInline,
+): Token {
+	throw new Error("unimplemented");
+}


### PR DESCRIPTION
This PR should get an head start around the markdown parser. 
The PR implements a first draft of the possible AST nodes we should support.

I know we want to support the Github-flavoured markdown and this nodes don't cover everything just yet (checkboxes, suggestions,  collapsible content).

I will implement them with another commit. In the meantime I would be great to have some feedback


FYI: here the "official" spec https://spec.commonmark.org/0.29/