### PR TITLE
Remove `input` parameter from ParserCore#tokenize and add getInputChar method

### DIFF
--- a/packages/@romejs/codec-json/parse.ts
+++ b/packages/@romejs/codec-json/parse.ts
@@ -168,9 +168,9 @@ export const createJSONParser = createParser((ParserCore) =>
 			this.pathKeys.pop();
 		}
 
-		tokenize(index: Number0, input: string) {
-			const nextChar = input[ob1Get0(index) + 1];
-			const char = input[ob1Get0(index)];
+		tokenize(index: Number0) {
+			const char = this.getInputCharOnly(index);
+			const nextChar = this.getInputCharOnly(index, 1);
 
 			// Line comment
 			if (char === "/" && nextChar === "/") {
@@ -212,11 +212,12 @@ export const createJSONParser = createParser((ParserCore) =>
 			// Single character token starters
 			switch (char) {
 				case '"': {
-					const [value] = this.readInputFrom(ob1Inc(index), isStringValueChar);
+					const [value, end, overflow] = this.readInputFrom(
+						ob1Inc(index),
+						isStringValueChar,
+					);
 
-					// Check for closed string (index is the current token index + string length + closing quote + 1 for the end char)
-					const end = ob1Add(ob1Add(index, value.length), 2);
-					if (input[ob1Get0(end) - 1] !== '"') {
+					if (overflow) {
 						throw this.unexpected({
 							description: descriptions.JSON.UNCLOSED_STRING,
 							start: this.getPositionFromIndex(end),
@@ -246,7 +247,8 @@ export const createJSONParser = createParser((ParserCore) =>
 						},
 					);
 
-					return this.finishValueToken("String", unescaped, end);
+					// increment to take the trailing quote
+					return this.finishValueToken("String", unescaped, ob1Inc(end));
 				}
 
 				case "'":

--- a/packages/@romejs/codec-semver/parse.ts
+++ b/packages/@romejs/codec-semver/parse.ts
@@ -26,7 +26,7 @@ import {
 	isDigit,
 } from "@romejs/parser-core";
 
-import {Number0, ob1Add, ob1Get0} from "@romejs/ob1";
+import {Number0, ob1Add} from "@romejs/ob1";
 import {descriptions} from "@romejs/diagnostics";
 
 type ParseMode = "version" | "range";
@@ -48,9 +48,9 @@ const createSemverParser = createParser((ParserCore) =>
 		mode: ParseMode;
 
 		// For some reason Flow will throw an error without the type casts...
-		tokenize(index: Number0, input: string): undefined | TokenValues<Tokens> {
-			const char = input[ob1Get0(index)];
-			const nextChar = input[ob1Get0(index) + 1];
+		tokenize(index: Number0): undefined | TokenValues<Tokens> {
+			const char = this.getInputCharOnly(index);
+			const nextChar = this.getInputCharOnly(index, 1);
 
 			if (
 				(char === "<" && nextChar === "=") ||
@@ -81,7 +81,11 @@ const createSemverParser = createParser((ParserCore) =>
 				return this.finishToken("Star");
 			}
 
-			if (input[ob1Get0(index) - 1] === " " && char === "-" && nextChar === " ") {
+			if (
+				this.getInputCharOnly(index, -1) === " " &&
+				char === "-" &&
+				nextChar === " "
+			) {
 				return this.finishToken("RangeDash");
 			}
 

--- a/packages/@romejs/codec-spdx-license/parse.ts
+++ b/packages/@romejs/codec-spdx-license/parse.ts
@@ -17,7 +17,7 @@ import {
 } from "@romejs/parser-core";
 import {getSPDXLicense, licenseNames} from "./index";
 import {descriptions} from "@romejs/diagnostics";
-import {Number0, ob1Get0, ob1Inc} from "@romejs/ob1";
+import {Number0} from "@romejs/ob1";
 
 //# Tokens
 type Tokens = BaseTokens & {
@@ -70,14 +70,15 @@ const createSPDXLicenseParser = createParser((ParserCore) =>
 	class SPDXLicenseParser extends ParserCore<Tokens> {
 		constructor(opts: SPDXLicenseParserOptions) {
 			super(opts, "parse/spdxLicense", {});
+			this.ignoreWhitespaceTokens = true;
 			this.loose = opts.loose === true;
 		}
 
 		loose: boolean;
 
 		// For some reason Flow will throw an error without the type casts...
-		tokenize(index: Number0, input: string) {
-			const char = input[ob1Get0(index)];
+		tokenize(index: Number0) {
+			const char = this.getInputCharOnly(index);
 
 			if (char === "+") {
 				return this.finishToken("Plus");
@@ -89,11 +90,6 @@ const createSPDXLicenseParser = createParser((ParserCore) =>
 
 			if (char === ")") {
 				return this.finishToken("ParenClose");
-			}
-
-			// Skip spaces
-			if (char === " ") {
-				return this.lookaheadToken(ob1Inc(index));
 			}
 
 			if (isWordChar(char)) {

--- a/packages/@romejs/core/server/fs/MemoryFileSystem.ts
+++ b/packages/@romejs/core/server/fs/MemoryFileSystem.ts
@@ -674,7 +674,12 @@ export default class MemoryFileSystem {
 			});
 		}
 
-		const project = projectManager.assertProjectExisting(path);
+		const project = projectManager.findProjectExisting(path);
+		if (project === undefined) {
+			// Project failed to load. We'll display the errors but failing hard here with assertProjectExisting will hide them.
+			return;
+		}
+
 		projectManager.declareManifest(project, isProjectPackage, def, diagnostics);
 
 		// Tell all workers of our discovery

--- a/packages/@romejs/core/test-worker/SnapshotManager.ts
+++ b/packages/@romejs/core/test-worker/SnapshotManager.ts
@@ -313,13 +313,15 @@ export default class SnapshotManager {
 					await this.emitDiagnostic(descriptions.SNAPSHOTS.REDUNDANT);
 				}
 			} else {
+				// Don't delete or write a snapshot if there are test failures as those failures may be hiding snapshot usages
+				if (!hasDiagnostics) {
+					continue;
+				}
+
 				if (existsOnDisk && !used) {
-					// Don't delete a snapshot if there are test failures as those failures may be hiding a snapshot usage
-					if (!hasDiagnostics) {
-						// If a snapshot wasn't used or is empty then delete it!
-						await removeFile(path);
-						this.snapshotCounts.deleted++;
-					}
+					// If a snapshot wasn't used or is empty then delete it!
+					await removeFile(path);
+					this.snapshotCounts.deleted++;
 				} else if (used && formatted !== raw) {
 					// Fresh snapshot!
 					await writeFile(path, formatted);

--- a/packages/@romejs/core/test-worker/SnapshotManager.ts
+++ b/packages/@romejs/core/test-worker/SnapshotManager.ts
@@ -314,7 +314,7 @@ export default class SnapshotManager {
 				}
 			} else {
 				// Don't delete or write a snapshot if there are test failures as those failures may be hiding snapshot usages
-				if (!hasDiagnostics) {
+				if (!hasDiagnostics && !this.options.updateSnapshots) {
 					continue;
 				}
 

--- a/packages/@romejs/core/test-worker/SnapshotParser.ts
+++ b/packages/@romejs/core/test-worker/SnapshotParser.ts
@@ -79,8 +79,8 @@ export const createSnapshotParser = createParser((ParserCore) =>
 			this.ignoreWhitespaceTokens = true;
 		}
 
-		tokenize(index: Number0, input: string) {
-			const char = input[ob1Get0(index)];
+		tokenize(index: Number0) {
+			const char = this.getInputCharOnly(index);
 
 			switch (char) {
 				case "#": {
@@ -90,14 +90,14 @@ export const createSnapshotParser = createParser((ParserCore) =>
 				}
 
 				case "`": {
-					const nextChar = input[ob1Get0(ob1Add(index, 1))];
-					const nextNextChar = input[ob1Get0(ob1Add(index, 2))];
+					const nextChar = this.getInputCharOnly(index, 1);
+					const nextNextChar = this.getInputCharOnly(index, 2);
 
 					if (nextChar === "`" && nextNextChar === "`") {
 						let codeOffset = ob1Add(index, 3);
 
 						let language: undefined | string;
-						if (input[ob1Get0(codeOffset)] !== "\n") {
+						if (this.getInputCharOnly(codeOffset) !== "\n") {
 							[language, codeOffset] = this.readInputFrom(
 								codeOffset,
 								isntNewline,
@@ -105,7 +105,7 @@ export const createSnapshotParser = createParser((ParserCore) =>
 						}
 
 						// Expect the first offset character to be a newline
-						if (input[ob1Get0(codeOffset)] === "\n") {
+						if (this.getInputCharOnly(codeOffset) === "\n") {
 							// Skip leading newline
 							codeOffset = ob1Add(codeOffset, 1);
 						} else {
@@ -119,7 +119,7 @@ export const createSnapshotParser = createParser((ParserCore) =>
 
 						let end = ob1Add(codeOffset, code.length);
 
-						if (isCodeBlockEnd(end, input)) {
+						if (isCodeBlockEnd(end, this.input)) {
 							// Check for trailing newline
 							if (code[code.length - 1] === "\n") {
 								// Trim trailing newline

--- a/packages/@romejs/css-parser/parse.ts
+++ b/packages/@romejs/css-parser/parse.ts
@@ -1,8 +1,15 @@
 import {CSSParserOptions, Tokens} from "./types";
-import {ParserOptions, createParser, isDigit, isHexDigit} from "@romejs/parser-core";
+import {
+	ParserOptions,
+	createParser,
+	isDigit,
+	isHexDigit,
+} from "@romejs/parser-core";
 import {DiagnosticCategory, descriptions} from "@romejs/diagnostics";
 import {Number0, ob1Add, ob1Inc} from "@romejs/ob1";
 import {
+	Symbols,
+	hexToUtf8,
 	isIdentifierStart,
 	isName,
 	isNameStart,
@@ -10,8 +17,6 @@ import {
 	isNumberStart,
 	isValidEscape,
 	isWhitespace,
-	hexToUtf8,
-	Symbols,
 } from "./utils";
 
 export const createCSSParser = createParser((ParserCore) =>
@@ -35,7 +40,7 @@ export const createCSSParser = createParser((ParserCore) =>
 			) {
 				return 2;
 			}
-		
+
 			return 1;
 		}
 
@@ -45,7 +50,12 @@ export const createCSSParser = createParser((ParserCore) =>
 					return ob1Inc(index);
 				}
 
-				if (isValidEscape(this.getInputCharOnly(index), this.getInputCharOnly(index, 1))) {
+				if (
+					isValidEscape(
+						this.getInputCharOnly(index),
+						this.getInputCharOnly(index, 1),
+					)
+				) {
 					index = this.consumeEscaped(index)[1];
 				} else {
 					index = ob1Inc(index);
@@ -77,7 +87,8 @@ export const createCSSParser = createParser((ParserCore) =>
 				if (
 					hexNumber === 0 ||
 					hexNumber > Symbols.MaxValue ||
-					(hexNumber >= Symbols.SurrogateMin && hexNumber <= Symbols.SurrogateMax)
+					(hexNumber >= Symbols.SurrogateMin &&
+					hexNumber <= Symbols.SurrogateMax)
 				) {
 					utf8Value = Symbols.Replace;
 				} else {
@@ -134,7 +145,10 @@ export const createCSSParser = createParser((ParserCore) =>
 				index = ob1Inc(index);
 			}
 
-			if (this.getInputCharOnly(index) === "." && isDigit(this.getInputCharOnly(index, 1))) {
+			if (
+				this.getInputCharOnly(index) === "." &&
+				isDigit(this.getInputCharOnly(index, 1))
+			) {
 				value += this.getInputCharOnly(index);
 				index = ob1Inc(index);
 
@@ -197,13 +211,17 @@ export const createCSSParser = createParser((ParserCore) =>
 					index = ob1Inc(index);
 				}
 
-				if (this.getInputCharOnly(index) === '"' || this.getInputCharOnly(index) === "'") {
+				if (
+					this.getInputCharOnly(index) === '"' ||
+					this.getInputCharOnly(index) === "'"
+				) {
 					return this.finishValueToken("Function", value, index);
 				}
 
 				if (
 					isWhitespace(this.getInputCharOnly(index)) &&
-					(this.getInputCharOnly(index, 1) === '"' || this.getInputCharOnly(index, 1) === "'")
+					(this.getInputCharOnly(index, 1) === '"' ||
+					this.getInputCharOnly(index, 1) === "'")
 				) {
 					return this.finishValueToken("Function", value, ob1Add(index, 1));
 				}
@@ -303,9 +321,7 @@ export const createCSSParser = createParser((ParserCore) =>
 			);
 		}
 
-		consumeURLToken(
-			index: Number0,
-		): Tokens["URL"] | Tokens["BadURL"] {
+		consumeURLToken(index: Number0): Tokens["URL"] | Tokens["BadURL"] {
 			let value = "";
 
 			while (isWhitespace(this.getInputCharOnly(index))) {
@@ -357,7 +373,12 @@ export const createCSSParser = createParser((ParserCore) =>
 				}
 
 				if (this.getInputCharOnly(index) === "\\") {
-					if (isValidEscape(this.getInputCharOnly(index), this.getInputCharOnly(index))) {
+					if (
+						isValidEscape(
+							this.getInputCharOnly(index),
+							this.getInputCharOnly(index),
+						)
+					) {
 						const [newValue, newIndex] = this.consumeEscaped(index);
 						index = newIndex;
 						value += newValue;
@@ -385,14 +406,20 @@ export const createCSSParser = createParser((ParserCore) =>
 			if (char === "/" && this.getInputCharOnly(index, 1) === "*") {
 				index = ob1Add(index, 2);
 				let value = "";
-				while (this.getInputCharOnly(index) !== "*" && this.getInputCharOnly(index, 1) !== "/" && !this.isEOF(index)) {
+				while (
+					this.getInputCharOnly(index) !== "*" &&
+					this.getInputCharOnly(index, 1) !== "/" &&
+					!this.isEOF(index)
+				) {
 					value += this.getInputCharOnly(index);
 					index = ob1Add(index, 1);
 				}
-				this.registerComment(this.comments.addComment({
-					type: "CommentBlock",
-					value,
-				}));
+				this.registerComment(
+					this.comments.addComment({
+						type: "CommentBlock",
+						value,
+					}),
+				);
 			}
 
 			if (isWhitespace(char)) {
@@ -406,9 +433,16 @@ export const createCSSParser = createParser((ParserCore) =>
 
 			if (char === "#") {
 				const nextChar = this.getInputCharOnly(index, 1);
-				if (isName(nextChar) || isValidEscape(nextChar, this.getInputCharOnly(index, 2))) {
+				if (
+					isName(nextChar) ||
+					isValidEscape(nextChar, this.getInputCharOnly(index, 2))
+				) {
 					const [value, endIndex] = this.consumeName(ob1Inc(index));
-					const isIdent = isIdentifierStart(this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2), this.getInputCharOnly(index, 3));
+					const isIdent = isIdentifierStart(
+						this.getInputCharOnly(index, 1),
+						this.getInputCharOnly(index, 2),
+						this.getInputCharOnly(index, 3),
+					);
 					return this.finishComplexToken(
 						"Hash",
 						{
@@ -434,7 +468,13 @@ export const createCSSParser = createParser((ParserCore) =>
 			}
 
 			if (char === "+") {
-				if (isNumberStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+				if (
+					isNumberStart(
+						char,
+						this.getInputCharOnly(index, 1),
+						this.getInputCharOnly(index, 2),
+					)
+				) {
 					return this.consumeNumberToken(index);
 				}
 
@@ -446,15 +486,30 @@ export const createCSSParser = createParser((ParserCore) =>
 			}
 
 			if (char === "-") {
-				if (isNumberStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+				if (
+					isNumberStart(
+						char,
+						this.getInputCharOnly(index, 1),
+						this.getInputCharOnly(index, 2),
+					)
+				) {
 					return this.consumeNumberToken(index);
 				}
 
-				if (this.getInputCharOnly(index, 1) === "-" && this.getInputCharOnly(index, 2) === ">") {
+				if (
+					this.getInputCharOnly(index, 1) === "-" &&
+					this.getInputCharOnly(index, 2) === ">"
+				) {
 					return this.finishToken("CDC", ob1Add(index, 3));
 				}
 
-				if (isIdentifierStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+				if (
+					isIdentifierStart(
+						char,
+						this.getInputCharOnly(index, 1),
+						this.getInputCharOnly(index, 2),
+					)
+				) {
 					return this.consumeIdentLikeToken(index);
 				}
 
@@ -462,7 +517,13 @@ export const createCSSParser = createParser((ParserCore) =>
 			}
 
 			if (char === ".") {
-				if (isNumberStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+				if (
+					isNumberStart(
+						char,
+						this.getInputCharOnly(index, 1),
+						this.getInputCharOnly(index, 2),
+					)
+				) {
 					return this.consumeNumberToken(index);
 				}
 
@@ -478,7 +539,13 @@ export const createCSSParser = createParser((ParserCore) =>
 			}
 
 			if (char === "@") {
-				if (isIdentifierStart(this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2), this.getInputCharOnly(index, 3))) {
+				if (
+					isIdentifierStart(
+						this.getInputCharOnly(index, 1),
+						this.getInputCharOnly(index, 2),
+						this.getInputCharOnly(index, 3),
+					)
+				) {
 					const [value, endIndex] = this.consumeName(ob1Inc(index));
 					return this.finishValueToken("AtKeyword", value, endIndex);
 				}
@@ -493,7 +560,7 @@ export const createCSSParser = createParser((ParserCore) =>
 				if (isValidEscape(char, this.getInputCharOnly(index, 1))) {
 					return this.consumeIdentLikeToken(index);
 				}
-				
+
 				this.unexpectedDiagnostic({
 					description: descriptions.CSS_PARSER.INVALID_ESCAPE,
 				});

--- a/packages/@romejs/css-parser/parse.ts
+++ b/packages/@romejs/css-parser/parse.ts
@@ -1,16 +1,8 @@
 import {CSSParserOptions, Tokens} from "./types";
-import {ParserOptions, createParser, isDigit} from "@romejs/parser-core";
+import {ParserOptions, createParser, isDigit, isHexDigit} from "@romejs/parser-core";
 import {DiagnosticCategory, descriptions} from "@romejs/diagnostics";
-import {Number0, ob1Add, ob1Get, ob1Get0, ob1Inc} from "@romejs/ob1";
-
+import {Number0, ob1Add, ob1Inc} from "@romejs/ob1";
 import {
-	consumeBadURL,
-	consumeChar,
-	consumeEscaped,
-	consumeName,
-	consumeNumber,
-	getChar,
-	getNewlineLength,
 	isIdentifierStart,
 	isName,
 	isNameStart,
@@ -18,6 +10,8 @@ import {
 	isNumberStart,
 	isValidEscape,
 	isWhitespace,
+	hexToUtf8,
+	Symbols,
 } from "./utils";
 
 export const createCSSParser = createParser((ParserCore) =>
@@ -34,39 +28,190 @@ export const createCSSParser = createParser((ParserCore) =>
 			this.options = opts;
 		}
 
+		getNewlineLength(index: Number0): number {
+			if (
+				this.getInputCharOnly(index) === Symbols.CarriageReturn &&
+				this.getInputCharOnly(index, 1) === Symbols.LineFeed
+			) {
+				return 2;
+			}
+		
+			return 1;
+		}
+
+		consumeBadURL(index: Number0): Number0 {
+			while (!this.isEOF(index)) {
+				if (this.getInputCharOnly(index) === ")") {
+					return ob1Inc(index);
+				}
+
+				if (isValidEscape(this.getInputCharOnly(index), this.getInputCharOnly(index, 1))) {
+					index = this.consumeEscaped(index)[1];
+				} else {
+					index = ob1Inc(index);
+				}
+			}
+			return index;
+		}
+
+		consumeEscaped(index: Number0): [string, Number0] {
+			let value = "";
+			index = ob1Add(index, 2);
+			const lastChar = this.getInputCharOnly(index, -1);
+
+			if (isHexDigit(lastChar)) {
+				let hexString = lastChar;
+				let utf8Value = "";
+
+				const [possibleHex] = this.getInputRange(index, 5);
+				for (const char of possibleHex) {
+					if (!isHexDigit(char)) {
+						break;
+					}
+
+					hexString += char;
+					index = ob1Inc(index);
+				}
+
+				const hexNumber = parseInt(hexString, 16);
+				if (
+					hexNumber === 0 ||
+					hexNumber > Symbols.MaxValue ||
+					(hexNumber >= Symbols.SurrogateMin && hexNumber <= Symbols.SurrogateMax)
+				) {
+					utf8Value = Symbols.Replace;
+				} else {
+					utf8Value = hexToUtf8(hexString);
+				}
+				value += utf8Value;
+
+				if (isWhitespace(this.getInputCharOnly(index))) {
+					index = ob1Add(index, this.getNewlineLength(index));
+				}
+			}
+
+			return [value, index];
+		}
+
+		consumeName(index: Number0): [string, Number0] {
+			let value = "";
+
+			while (!this.isEOF(index)) {
+				const char1 = this.getInputCharOnly(index);
+				const char2 = this.getInputCharOnly(index, 1);
+
+				if (isName(char1)) {
+					value += char1;
+					index = ob1Inc(index);
+					continue;
+				}
+
+				if (isValidEscape(char1, char2)) {
+					const [newValue, newIndex] = this.consumeEscaped(index);
+					value += newValue;
+					index = newIndex;
+					continue;
+				}
+
+				break;
+			}
+
+			return [value, index];
+		}
+
+		consumeNumber(index: Number0): [Number0, number, string] {
+			const char = this.getInputCharOnly(index);
+			let value = "";
+			let type = "integer";
+
+			if (char === "+" || char === "-") {
+				value += char;
+				index = ob1Inc(index);
+			}
+
+			while (isDigit(this.getInputCharOnly(index))) {
+				value += this.getInputCharOnly(index);
+				index = ob1Inc(index);
+			}
+
+			if (this.getInputCharOnly(index) === "." && isDigit(this.getInputCharOnly(index, 1))) {
+				value += this.getInputCharOnly(index);
+				index = ob1Inc(index);
+
+				value += this.getInputCharOnly(index);
+				index = ob1Inc(index);
+
+				type = "number";
+
+				while (isDigit(this.getInputCharOnly(index))) {
+					value += this.getInputCharOnly(index);
+					index = ob1Inc(index);
+				}
+			}
+
+			const char1 = this.getInputCharOnly(index);
+			const char2 = this.getInputCharOnly(index, 1);
+			const char3 = this.getInputCharOnly(index, 2);
+
+			if (char1 === "E" || char1 === "e") {
+				if (isDigit(char2)) {
+					value += this.getInputCharOnly(index);
+					index = ob1Inc(index);
+
+					value += this.getInputCharOnly(index);
+					index = ob1Inc(index);
+				} else if ((char2 === "-" || char2 === "+") && isDigit(char3)) {
+					value += this.getInputCharOnly(index);
+					index = ob1Inc(index);
+
+					value += this.getInputCharOnly(index);
+					index = ob1Inc(index);
+
+					value += this.getInputCharOnly(index);
+					index = ob1Inc(index);
+
+					while (isDigit(this.getInputCharOnly(index))) {
+						value += this.getInputCharOnly(index);
+						index = ob1Inc(index);
+					}
+				}
+			}
+
+			return [index, parseFloat(value), type];
+		}
+
 		consumeIdentLikeToken(
 			index: Number0,
-			input: string,
 		): Tokens["Function"] | Tokens["Ident"] | Tokens["URL"] | Tokens["BadURL"] {
-			const [newIndex, name] = consumeName(index, input);
+			const [name, newIndex] = this.consumeName(index);
 			index = newIndex;
 			let value = name;
 
-			if (/url/gi.test(value) && getChar(index, input) === "(") {
+			if (/url/gi.test(value) && this.getInputCharOnly(index) === "(") {
 				index = ob1Inc(index);
 
 				while (
-					isWhitespace(getChar(index, input)) &&
-					isWhitespace(getChar(index, input, 1))
+					isWhitespace(this.getInputCharOnly(index)) &&
+					isWhitespace(this.getInputCharOnly(index, 1))
 				) {
 					index = ob1Inc(index);
 				}
 
-				if (getChar(index, input) === '"' || getChar(index, input) === "'") {
+				if (this.getInputCharOnly(index) === '"' || this.getInputCharOnly(index) === "'") {
 					return this.finishValueToken("Function", value, index);
 				}
 
 				if (
-					isWhitespace(getChar(index, input)) &&
-					(getChar(index, input, 1) === '"' || getChar(index, input, 1) === "'")
+					isWhitespace(this.getInputCharOnly(index)) &&
+					(this.getInputCharOnly(index, 1) === '"' || this.getInputCharOnly(index, 1) === "'")
 				) {
 					return this.finishValueToken("Function", value, ob1Add(index, 1));
 				}
 
-				return this.consumeURLToken(index, input);
+				return this.consumeURLToken(index);
 			}
 
-			if (getChar(index, input) === "(") {
+			if (this.getInputCharOnly(index) === "(") {
 				return this.finishValueToken("Function", value, ob1Inc(index));
 			}
 
@@ -75,28 +220,27 @@ export const createCSSParser = createParser((ParserCore) =>
 
 		consumeStringToken(
 			index: Number0,
-			input: string,
 			endChar?: string,
 		): Tokens["String"] | Tokens["BadString"] {
 			let value = "";
 
 			if (!endChar) {
-				[index, endChar] = consumeChar(index, input);
+				[endChar, index] = this.getInputChar(index);
 			}
 
-			while (ob1Get(index) < input.length) {
-				const char = getChar(index, input);
-				const nextChar = getChar(index, input, 1);
+			while (!this.isEOF(index)) {
+				const char = this.getInputCharOnly(index);
+				const nextChar = this.getInputCharOnly(index, 1);
 
 				if (char === endChar) {
 					return this.finishValueToken("String", value, ob1Inc(index));
 				} else if (this.isEOF(index)) {
-					this.createDiagnostic({
+					this.unexpectedDiagnostic({
 						description: descriptions.CSS_PARSER.UNTERMINATED_STRING,
 					});
 					return this.finishValueToken("String", value, ob1Inc(index));
 				} else if (isNewline(char)) {
-					this.createDiagnostic({
+					this.unexpectedDiagnostic({
 						description: descriptions.CSS_PARSER.UNTERMINATED_STRING,
 					});
 					return this.finishToken("BadString", index);
@@ -105,9 +249,9 @@ export const createCSSParser = createParser((ParserCore) =>
 						continue;
 					}
 					if (isNewline(nextChar)) {
-						index = ob1Add(index, getNewlineLength(ob1Inc(index), input));
+						index = ob1Add(index, this.getNewlineLength(ob1Inc(index)));
 					} else if (isValidEscape(char, nextChar)) {
-						const [newIndex, newValue] = consumeEscaped(index, input);
+						const [newValue, newIndex] = this.consumeEscaped(index);
 						value += newValue;
 						index = newIndex;
 					}
@@ -122,19 +266,18 @@ export const createCSSParser = createParser((ParserCore) =>
 
 		consumeNumberToken(
 			index: Number0,
-			input: string,
 		): Tokens["Percentage"] | Tokens["Dimension"] | Tokens["Number"] {
-			const [newIndex, numberValue, numberType] = consumeNumber(index, input);
+			const [newIndex, numberValue, numberType] = this.consumeNumber(index);
 			index = newIndex;
 
 			if (
 				isIdentifierStart(
-					getChar(index, input),
-					getChar(index, input, 1),
-					getChar(index, input, 2),
+					this.getInputCharOnly(index),
+					this.getInputCharOnly(index, 1),
+					this.getInputCharOnly(index, 2),
 				)
 			) {
-				const [endIndex, unit] = consumeName(index, input);
+				const [unit, endIndex] = this.consumeName(index);
 				return this.finishComplexToken(
 					"Dimension",
 					{
@@ -146,7 +289,7 @@ export const createCSSParser = createParser((ParserCore) =>
 				);
 			}
 
-			if (getChar(index, input) === "%") {
+			if (this.getInputCharOnly(index) === "%") {
 				return this.finishValueToken("Percentage", numberValue, index);
 			}
 
@@ -162,105 +305,110 @@ export const createCSSParser = createParser((ParserCore) =>
 
 		consumeURLToken(
 			index: Number0,
-			input: string,
 		): Tokens["URL"] | Tokens["BadURL"] {
 			let value = "";
 
-			while (isWhitespace(getChar(index, input))) {
+			while (isWhitespace(this.getInputCharOnly(index))) {
 				index = ob1Inc(index);
 			}
 
-			while (ob1Get(index) < input.length) {
-				if (getChar(index, input) === ")") {
+			while (!this.isEOF(index)) {
+				if (this.getInputCharOnly(index) === ")") {
 					return this.finishValueToken("URL", value, ob1Inc(index));
 				}
 
 				if (this.isEOF(index)) {
-					this.createDiagnostic({
+					this.unexpectedDiagnostic({
 						description: descriptions.CSS_PARSER.UNTERMINATED_URL,
 					});
 					return this.finishValueToken("URL", value);
 				}
 
-				if (isWhitespace(getChar(index, input))) {
-					while (isWhitespace(getChar(index, input))) {
+				if (isWhitespace(this.getInputCharOnly(index))) {
+					while (isWhitespace(this.getInputCharOnly(index))) {
 						index = ob1Inc(index);
 					}
 
-					if (getChar(index, input) === ")") {
+					if (this.getInputCharOnly(index) === ")") {
 						return this.finishValueToken("URL", value, ob1Inc(index));
 					}
 
 					if (this.isEOF(index)) {
-						this.createDiagnostic({
+						this.unexpectedDiagnostic({
 							description: descriptions.CSS_PARSER.UNTERMINATED_URL,
 						});
 						return this.finishValueToken("URL", value);
 					}
 
-					[index] = consumeBadURL(index, input);
+					index = this.consumeBadURL(index);
 					return this.finishToken("BadURL", index);
 				}
 
 				if (
-					getChar(index, input) === '"' ||
-					getChar(index, input) === "'" ||
-					getChar(index, input) === "("
+					this.getInputCharOnly(index) === '"' ||
+					this.getInputCharOnly(index) === "'" ||
+					this.getInputCharOnly(index) === "("
 				) {
-					this.createDiagnostic({
+					this.unexpectedDiagnostic({
 						description: descriptions.CSS_PARSER.UNTERMINATED_URL,
 					});
-					[index] = consumeBadURL(index, input);
+					index = this.consumeBadURL(index);
 					return this.finishToken("BadURL", index);
 				}
 
-				if (getChar(index, input) === "\\") {
-					if (isValidEscape(getChar(index, input), getChar(index, input))) {
-						const [newIndex, newValue] = consumeEscaped(index, input);
+				if (this.getInputCharOnly(index) === "\\") {
+					if (isValidEscape(this.getInputCharOnly(index), this.getInputCharOnly(index))) {
+						const [newValue, newIndex] = this.consumeEscaped(index);
 						index = newIndex;
 						value += newValue;
 						continue;
 					}
 
-					this.createDiagnostic({
+					this.unexpectedDiagnostic({
 						description: descriptions.CSS_PARSER.UNTERMINATED_URL,
 					});
-					[index] = consumeBadURL(index, input);
+					index = this.consumeBadURL(index);
 					return this.finishToken("BadURL", index);
 				}
 
-				value += getChar(index, input);
+				value += this.getInputCharOnly(index);
 				index = ob1Inc(index);
 			}
 
 			throw new Error("Unrecoverable state due to bad URL");
 		}
 
-		tokenize(index: Number0, input: string) {
-			function getChar(offset = 0) {
-				return input[ob1Get0(index) + offset];
-			}
+		tokenize(index: Number0) {
+			const char = this.getInputCharOnly(index);
 
-			if (getChar() === "/" && getChar(1) === "*") {
+			// Skip over comments
+			if (char === "/" && this.getInputCharOnly(index, 1) === "*") {
 				index = ob1Add(index, 2);
-				while (getChar() !== "*" && getChar(1) !== "/") {
+				let value = "";
+				while (this.getInputCharOnly(index) !== "*" && this.getInputCharOnly(index, 1) !== "/" && !this.isEOF(index)) {
+					value += this.getInputCharOnly(index);
 					index = ob1Add(index, 1);
 				}
+				this.registerComment(this.comments.addComment({
+					type: "CommentBlock",
+					value,
+				}));
 			}
 
-			if (isWhitespace(getChar())) {
+			if (isWhitespace(char)) {
 				const endIndex = this.readInputFrom(index, isWhitespace)[1];
 				return this.finishToken("Whitespace", endIndex);
 			}
 
-			if (getChar() === '"') {
-				return this.consumeStringToken(index, input);
+			if (char === '"') {
+				return this.consumeStringToken(index);
 			}
 
-			if (getChar() === "#") {
-				if (isName(getChar(1)) || isValidEscape(getChar(1), getChar(2))) {
-					const [endIndex, value] = consumeName(ob1Inc(index), input);
-					const isIdent = isIdentifierStart(getChar(1), getChar(2), getChar(3));
+			if (char === "#") {
+				const nextChar = this.getInputCharOnly(index, 1);
+				if (isName(nextChar) || isValidEscape(nextChar, this.getInputCharOnly(index, 2))) {
+					const [value, endIndex] = this.consumeName(ob1Inc(index));
+					const isIdent = isIdentifierStart(this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2), this.getInputCharOnly(index, 3));
 					return this.finishComplexToken(
 						"Hash",
 						{
@@ -270,106 +418,109 @@ export const createCSSParser = createParser((ParserCore) =>
 						endIndex,
 					);
 				}
-				return this.finishValueToken("Delim", getChar());
+				return this.finishValueToken("Delim", char);
 			}
 
-			if (getChar() === "'") {
-				return this.consumeStringToken(index, input);
+			if (char === "'") {
+				return this.consumeStringToken(index);
 			}
 
-			if (getChar() === "(") {
+			if (char === "(") {
 				return this.finishToken("LeftParen");
 			}
 
-			if (getChar() === ")") {
+			if (char === ")") {
 				return this.finishToken("RightParen");
 			}
 
-			if (getChar() === "+") {
-				if (isNumberStart(getChar(), getChar(1), getChar(2))) {
-					return this.consumeNumberToken(index, input);
+			if (char === "+") {
+				if (isNumberStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+					return this.consumeNumberToken(index);
 				}
-				return this.finishValueToken("Delim", getChar());
+
+				return this.finishValueToken("Delim", char);
 			}
 
-			if (getChar() === ",") {
+			if (char === ",") {
 				return this.finishToken("Comma");
 			}
 
-			if (getChar() === "-") {
-				if (isNumberStart(getChar(), getChar(1), getChar(2))) {
-					return this.consumeNumberToken(index, input);
+			if (char === "-") {
+				if (isNumberStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+					return this.consumeNumberToken(index);
 				}
 
-				if (getChar(1) === "-" && getChar(2) === ">") {
+				if (this.getInputCharOnly(index, 1) === "-" && this.getInputCharOnly(index, 2) === ">") {
 					return this.finishToken("CDC", ob1Add(index, 3));
 				}
 
-				if (isIdentifierStart(getChar(), getChar(1), getChar(2))) {
-					return this.consumeIdentLikeToken(index, input);
+				if (isIdentifierStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+					return this.consumeIdentLikeToken(index);
 				}
 
-				return this.finishValueToken("Delim", getChar());
+				return this.finishValueToken("Delim", char);
 			}
 
-			if (getChar() === ".") {
-				if (isNumberStart(getChar(), getChar(1), getChar(2))) {
-					return this.consumeNumberToken(index, input);
+			if (char === ".") {
+				if (isNumberStart(char, this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2))) {
+					return this.consumeNumberToken(index);
 				}
-				return this.finishValueToken("Delim", getChar());
+
+				return this.finishValueToken("Delim", char);
 			}
 
-			if (getChar() === ":") {
+			if (char === ":") {
 				return this.finishToken("Colon");
 			}
 
-			if (getChar() === ";") {
+			if (char === ";") {
 				return this.finishToken("Semi");
 			}
 
-			if (getChar() === "@") {
-				if (isIdentifierStart(getChar(1), getChar(2), getChar(3))) {
-					const [endIndex, value] = consumeName(ob1Inc(index), input);
+			if (char === "@") {
+				if (isIdentifierStart(this.getInputCharOnly(index, 1), this.getInputCharOnly(index, 2), this.getInputCharOnly(index, 3))) {
+					const [value, endIndex] = this.consumeName(ob1Inc(index));
 					return this.finishValueToken("AtKeyword", value, endIndex);
 				}
-				return this.finishValueToken("Delim", getChar());
+				return this.finishValueToken("Delim", char);
 			}
 
-			if (getChar() === "[") {
+			if (char === "[") {
 				return this.finishToken("LeftSquareBracket");
 			}
 
-			if (getChar() === "\\") {
-				if (isValidEscape(getChar(), getChar(1))) {
-					return this.consumeIdentLikeToken(index, input);
+			if (char === "\\") {
+				if (isValidEscape(char, this.getInputCharOnly(index, 1))) {
+					return this.consumeIdentLikeToken(index);
 				}
-				this.createDiagnostic({
+				
+				this.unexpectedDiagnostic({
 					description: descriptions.CSS_PARSER.INVALID_ESCAPE,
 				});
-				return this.finishValueToken("Delim", getChar());
+				return this.finishValueToken("Delim", char);
 			}
 
-			if (getChar() === "]") {
+			if (char === "]") {
 				return this.finishToken("RightSquareBracket");
 			}
 
-			if (getChar() === "{") {
+			if (char === "{") {
 				return this.finishToken("LeftCurlyBracket");
 			}
 
-			if (getChar() === "}") {
+			if (char === "}") {
 				return this.finishToken("RightCurlyBracket");
 			}
 
-			if (isDigit(getChar())) {
-				return this.consumeNumberToken(index, input);
+			if (isDigit(char)) {
+				return this.consumeNumberToken(index);
 			}
 
-			if (isNameStart(getChar())) {
-				return this.consumeIdentLikeToken(index, input);
+			if (isNameStart(char)) {
+				return this.consumeIdentLikeToken(index);
 			}
 
-			return this.finishValueToken("Delim", getChar());
+			return this.finishValueToken("Delim", char);
 		}
 	}
 );

--- a/packages/@romejs/css-parser/utils.ts
+++ b/packages/@romejs/css-parser/utils.ts
@@ -1,5 +1,5 @@
 import {Number0, ob1Add, ob1Get, ob1Inc} from "@romejs/ob1";
-import {isAlpha, isDigit, isHexDigit} from "@romejs/parser-core";
+import {isAlpha, isDigit} from "@romejs/parser-core";
 
 export const Symbols = {
 	CarriageReturn: "\r",
@@ -14,157 +14,6 @@ export const Symbols = {
 	Tab: "\t",
 };
 
-export function consumeBadURL(index: Number0, input: string): [Number0] {
-	while (ob1Get(index) < input.length) {
-		if (getChar(index, input) === ")") {
-			return [ob1Inc(index)];
-		}
-
-		if (isValidEscape(getChar(index, input), getChar(index, input, 1))) {
-			[index] = consumeEscaped(index, input);
-		} else {
-			index = ob1Inc(index);
-		}
-	}
-	return [index];
-}
-
-export function consumeChar(index: Number0, input: string): [Number0, string] {
-	return [ob1Inc(index), getChar(index, input)];
-}
-
-export function consumeEscaped(index: Number0, input: string): [Number0, string] {
-	let value = "";
-	index = ob1Add(index, 2);
-	const lastChar = getChar(index, input, -1);
-
-	if (isHexDigit(lastChar)) {
-		const maxOffset = Math.min(input.length, ob1Get(index) + 5);
-		let hexString = lastChar;
-		let utf8Value = "";
-
-		while (ob1Get(index) < maxOffset) {
-			if (!isHexDigit(getChar(index, input))) {
-				break;
-			}
-			hexString += getChar(index, input);
-			index = ob1Inc(index);
-		}
-		const hexNumber = parseInt(hexString, 16);
-		if (
-			hexNumber === 0 ||
-			hexNumber > Symbols.MaxValue ||
-			(hexNumber >= Symbols.SurrogateMin && hexNumber <= Symbols.SurrogateMax)
-		) {
-			utf8Value = Symbols.Replace;
-		} else {
-			utf8Value = hexToUtf8(hexString);
-		}
-		value += utf8Value;
-
-		if (isWhitespace(input[ob1Get(index)])) {
-			index = ob1Add(index, getNewlineLength(index, input));
-		}
-	}
-
-	return [index, value];
-}
-
-export function consumeName(index: Number0, input: string): [Number0, string] {
-	let value = "";
-
-	while (ob1Get(index) < input.length) {
-		const char1 = getChar(index, input);
-		const char2 = getChar(index, input, 1);
-
-		if (isName(char1)) {
-			value += char1;
-			index = ob1Inc(index);
-			continue;
-		}
-
-		if (isValidEscape(char1, char2)) {
-			const [newIndex, newValue] = consumeEscaped(index, input);
-			value += newValue;
-			index = newIndex;
-			continue;
-		}
-
-		break;
-	}
-
-	return [index, value];
-}
-
-export function consumeNumber(
-	index: Number0,
-	input: string,
-): [Number0, number, string] {
-	const char = getChar(index, input);
-	let value = "";
-	let type = "integer";
-
-	if (char === "+" || char === "-") {
-		value += char;
-		index = ob1Inc(index);
-	}
-
-	while (isDigit(getChar(index, input))) {
-		value += getChar(index, input);
-		index = ob1Inc(index);
-	}
-
-	if (getChar(index, input) === "." && isDigit(getChar(index, input, 1))) {
-		value += getChar(index, input);
-		index = ob1Inc(index);
-
-		value += getChar(index, input);
-		index = ob1Inc(index);
-
-		type = "number";
-
-		while (isDigit(getChar(index, input))) {
-			value += getChar(index, input);
-			index = ob1Inc(index);
-		}
-	}
-
-	const char1 = getChar(index, input);
-	const char2 = getChar(index, input, 1);
-	const char3 = getChar(index, input, 2);
-
-	if (char1 === "E" || char1 === "e") {
-		if (isDigit(char2)) {
-			value += getChar(index, input);
-			index = ob1Inc(index);
-
-			value += getChar(index, input);
-			index = ob1Inc(index);
-		} else if ((char2 === "-" || char2 === "+") && isDigit(char3)) {
-			value += getChar(index, input);
-			index = ob1Inc(index);
-
-			value += getChar(index, input);
-			index = ob1Inc(index);
-
-			value += getChar(index, input);
-			index = ob1Inc(index);
-
-			while (isDigit(getChar(index, input))) {
-				value += getChar(index, input);
-				index = ob1Inc(index);
-			}
-		}
-	}
-
-	return [index, parseFloat(value), type];
-}
-
-export function getChar(index: Number0, input: string, offset = 0): string {
-	const targetIndex = ob1Get(index) + offset;
-	return input[targetIndex];
-}
-
 export function getCodePoint(char: string): number {
 	if (!char) {
 		return -1;
@@ -178,17 +27,6 @@ export function getCodePoint(char: string): number {
 	}
 
 	throw new Error("Input was not 1 character long");
-}
-
-export function getNewlineLength(index: Number0, input: string): number {
-	if (
-		getChar(index, input) === Symbols.CarriageReturn &&
-		getChar(index, input, 1) === Symbols.LineFeed
-	) {
-		return 2;
-	}
-
-	return 1;
 }
 
 export function hexToUtf8(hex: string): string {

--- a/packages/@romejs/css-parser/utils.ts
+++ b/packages/@romejs/css-parser/utils.ts
@@ -1,4 +1,3 @@
-import {Number0, ob1Add, ob1Get, ob1Inc} from "@romejs/ob1";
 import {isAlpha, isDigit} from "@romejs/parser-core";
 
 export const Symbols = {

--- a/packages/@romejs/html-parser/index.ts
+++ b/packages/@romejs/html-parser/index.ts
@@ -73,7 +73,6 @@ const createHTMLParser = createParser((ParserCore, ParserWithRequiredPath) =>
 
 		tokenizeWithState(
 			index: Number0,
-			input: string,
 			state: State,
 		):
 			| undefined
@@ -81,8 +80,8 @@ const createHTMLParser = createParser((ParserCore, ParserWithRequiredPath) =>
 					token: TokenValues<Tokens>;
 					state: State;
 				} {
-			const escaped = isEscaped(index, input);
-			const char = input[ob1Get0(index)];
+			const escaped = isEscaped(index, this.input);
+			const char = this.getInputCharOnly(index);
 
 			if (!escaped && state.inTagHead) {
 				if (char === " ") {
@@ -139,7 +138,7 @@ const createHTMLParser = createParser((ParserCore, ParserWithRequiredPath) =>
 				}
 			}
 
-			if (isTagStartChar(index, input)) {
+			if (isTagStartChar(index, this.input)) {
 				return {
 					state: {
 						...state,

--- a/packages/@romejs/js-parser/test-fixtures/core/uncategorised/441/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/core/uncategorised/441/input.test.md
@@ -153,7 +153,7 @@ JSRoot {
 								}
 							}
 							JSRegExpCharacter {
-								value: undefined
+								value: ""
 								loc: Object {
 									filename: "input.js"
 									end: Object {

--- a/packages/@romejs/js-parser/test-fixtures/esprima/invalid-syntax/migrated_0157/input.test.md
+++ b/packages/@romejs/js-parser/test-fixtures/esprima/invalid-syntax/migrated_0157/input.test.md
@@ -153,7 +153,7 @@ JSRoot {
 								}
 							}
 							JSRegExpCharacter {
-								value: undefined
+								value: ""
 								loc: Object {
 									filename: "input.js"
 									end: Object {

--- a/packages/@romejs/js-parser/tokenizer/index.ts
+++ b/packages/@romejs/js-parser/tokenizer/index.ts
@@ -327,7 +327,7 @@ function pushComment(
 	}
 
 	if (parser.isLookahead === false) {
-		parser.addComment(comment);
+		parser.registerComment(comment);
 	}
 
 	if (parser.shouldCreateToken()) {

--- a/packages/@romejs/parser-core/index.ts
+++ b/packages/@romejs/parser-core/index.ts
@@ -819,7 +819,7 @@ export class ParserCore<
 
 	//# Comments
 
-	addComment(comment: AnyComment) {
+	registerComment(comment: AnyComment) {
 		this.state.comments.push(comment);
 		this.state.trailingComments.push(comment);
 		this.state.leadingComments.push(comment);

--- a/packages/@romejs/parser-core/index.ts
+++ b/packages/@romejs/parser-core/index.ts
@@ -271,14 +271,13 @@ export class ParserCore<
 	}
 
 	// Tokenize method that must be implemented by subclasses
-	tokenize(index: Number0, input: string): undefined | TokenValues<Tokens> {
+	tokenize(index: Number0): undefined | TokenValues<Tokens> {
 		throw new Error("Unimplemented");
 	}
 
 	// Alternate tokenize method to allow that allows the use of state
 	tokenizeWithState(
 		index: Number0,
-		input: string,
 		state: State,
 	):
 		| undefined
@@ -286,7 +285,7 @@ export class ParserCore<
 				token: TokenValues<Tokens>;
 				state: State;
 			} {
-		const token = this.tokenize(index, input);
+		const token = this.tokenize(index);
 		if (token !== undefined) {
 			return {token, state};
 		} else {
@@ -296,7 +295,6 @@ export class ParserCore<
 
 	_tokenizeWithState(
 		index: Number0,
-		input: string,
 		state: State,
 	):
 		| undefined
@@ -305,7 +303,7 @@ export class ParserCore<
 				state: State;
 			} {
 		if (this.ignoreWhitespaceTokens) {
-			switch (input[ob1Get0(index)]) {
+			switch (this.getInputCharOnly(index)) {
 				case " ":
 				case "\t":
 				case "\r":
@@ -314,7 +312,7 @@ export class ParserCore<
 			}
 		}
 
-		return this.tokenizeWithState(index, input, state);
+		return this.tokenizeWithState(index, state);
 	}
 
 	// Get the current token
@@ -431,7 +429,7 @@ export class ParserCore<
 		this.tokenizing = true;
 
 		// Tokenize and do some validation
-		const nextToken = this._tokenizeWithState(index, this.input, this.state);
+		const nextToken = this._tokenizeWithState(index, this.state);
 		if (nextToken === undefined) {
 			throw this.unexpected({
 				start: this.getPositionFromIndex(index),
@@ -593,6 +591,39 @@ export class ParserCore<
 		}
 	}
 
+	getInputRange(
+		start: Number0,
+		count: number,
+		startOffset?: number,
+	): [string, Number0] {
+		// Allow passing in an `offset` to avoid callsites having to do `ob1Add` themselves
+		const startIndex = ob1Get0(
+			startOffset === undefined ? start : ob1Add(start, startOffset),
+		);
+		const endIndex = Math.min(startIndex + count, this.input.length - 1);
+		return [this.input.slice(startIndex, endIndex), ob1Coerce0(endIndex + 1)];
+	}
+
+	getInputCharOnly(index: Number0, offset?: number): string {
+		return this.getInputChar(index, offset)[0];
+	}
+
+	getInputChar(index: Number0, offset?: number): [string, Number0] {
+		const {input} = this;
+
+		// Allow passing in an `offset` to avoid callsites having to do `ob1Add` themselves
+		const i = ob1Get0(offset === undefined ? index : ob1Add(index, offset));
+
+		const end = ob1Coerce0(i + 1);
+
+		// Allow an overflow since we call this method to check for trailing characters
+		if (i >= input.length || i < 0) {
+			return ["", end];
+		}
+
+		return [input[i], end];
+	}
+
 	// Read from the input starting at the specified index, until the callback returns false
 	readInputFrom(
 		index: Number0,
@@ -624,6 +655,7 @@ export class ParserCore<
 	getRawInput(start: Number0, end: Number0): string {
 		return this.input.slice(ob1Get0(start), ob1Get0(end));
 	}
+
 	getLoc(node: undefined | NodeBase): SourceLocation {
 		if (node === undefined || node.loc === undefined) {
 			throw new Error("Tried to fetch node loc start but none found");

--- a/packages/@romejs/path-match/parse.ts
+++ b/packages/@romejs/path-match/parse.ts
@@ -60,9 +60,9 @@ const createPathMatchParser = createParser((ParserCore) =>
 			return true;
 		}
 
-		tokenize(index: Number0, input: string) {
-			const char = input[ob1Get0(index)];
-			const nextChar = input[ob1Get0(index) + 1];
+		tokenize(index: Number0) {
+			const char = this.getInputCharOnly(index);
+			const nextChar = this.getInputCharOnly(index, 1);
 
 			if (char === "*") {
 				if (nextChar === "*") {

--- a/packages/@romejs/string-markup/parse.ts
+++ b/packages/@romejs/string-markup/parse.ts
@@ -148,7 +148,6 @@ const createStringMarkupParser = createParser((ParserCore) =>
 
 		tokenizeWithState(
 			index: Number0,
-			input: string,
 			state: State,
 		):
 			| undefined
@@ -156,8 +155,8 @@ const createStringMarkupParser = createParser((ParserCore) =>
 					token: TokenValues<Tokens>;
 					state: State;
 				} {
-			const escaped = isEscaped(index, input);
-			const char = input[ob1Get0(index)];
+			const escaped = isEscaped(index, this.input);
+			const char = this.getInputCharOnly(index);
 
 			if (!escaped && state.inTagHead) {
 				if (char === " ") {
@@ -221,7 +220,7 @@ const createStringMarkupParser = createParser((ParserCore) =>
 				}
 			}
 
-			if (isTagStartChar(index, input)) {
+			if (isTagStartChar(index, this.input)) {
 				return {
 					state: {
 						...state,


### PR DESCRIPTION
`tokenize` no longer has an `input` parameter which was just passing in `this.input` anyway. There's no `getInputChar`, `getInputCharOnly` and `getInputRange` to help with getting characters from an index, including adding an offset etc.